### PR TITLE
Add CI to autodeploy on itestnet

### DIFF
--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -31,5 +31,6 @@ jobs:
           tags: |
             hermeznetwork/hermez-bridge
             hermeznetwork/hermez-bridge:1.5-integration
+            hermeznetwork/hermez-bridge:1.5-itestnet
           build-args: |
             PRIVATE_TOKEN=${{secrets.GIT_TOKEN}}


### PR DESCRIPTION
### What does this PR do?

Push the docker image tagget as needed for automatic deploy on internal-testnet

### Reviewers

- @ARR552 

Codeowner reviewers:

- @ARR552 