### PR TITLE
Do not use ssh key to checkout code for updatedeps

### DIFF
--- a/.github/workflows/updatedeps.yml
+++ b/.github/workflows/updatedeps.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-      with:
-        ssh-key: ${{ secrets.UPDATE_DEPS_SSH_PK }}
     - name: Install Go
       uses: actions/setup-go@v1
       with:
@@ -34,6 +32,7 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         commit-message: update external dependencies
         title: Update external dependencies
         body: Check for new images, test vectors and proto files and update the code to use them.


### PR DESCRIPTION
Closes #162

### What does this PR do?
Uses a personal access token instead of the ssh deploy key for creating PRs in updatedeps.

### Reviewers

@arnaubennassar 
@cool-develope 