### PR TITLE
Make ClaimTxManager optional

### DIFF
--- a/claimtxman/config.go
+++ b/claimtxman/config.go
@@ -4,6 +4,8 @@ import "github.com/0xPolygonHermez/zkevm-node/config/types"
 
 // Config is configuration for L2 claim transaction manager
 type Config struct {
+	Enabled bool `mapstructure:"-" json:"-"`
+
 	// FrequencyToMonitorTxs frequency of the resending failed txs
 	FrequencyToMonitorTxs types.Duration `mapstructure:"FrequencyToMonitorTxs"`
 	// PrivateKey defines the key store file that is going

--- a/config/config.go
+++ b/config/config.go
@@ -83,6 +83,8 @@ func Load(configFilePath string, network string) (*Config, error) {
 		cfg.loadNetworkConfig(network)
 	}
 
+	cfg.ClaimTxManager.Enabled = viper.IsSet("ClaimTxManager")
+
 	cfgJSON, _ := json.MarshalIndent(cfg, "", "  ")
 	log.Infof("Configuration loaded: \n%s\n", string(cfgJSON))
 	return &cfg, nil

--- a/config/default.go
+++ b/config/default.go
@@ -15,10 +15,6 @@ Host = "zkevm-bridge-db"
 Port = "5432"
 MaxConns = 20
 
-[ClaimTxManager]
-FrequencyToMonitorTxs = "1s"
-PrivateKey = {Path = "./test/test.keystore", Password = "testonly"}
-
 [Etherman]
 L1URL = "http://localhost:8545"
 L2URLs = [""]
@@ -46,5 +42,4 @@ BridgeVersion = "v1"
     Host = "zkevm-bridge-db"
     Port = "5432"
     MaxConns = 20
-
 `


### PR DESCRIPTION
Closes #418.

### What does this PR do?

Allows running the bridge without the autoclaim functionality just by removing the configuration from the config file. In that case the user will receive a warning log message just in case this was not intentional.