### PR TITLE
Use the network ID when updating L2 deposits

### DIFF
--- a/claimtxman/claimtxman.go
+++ b/claimtxman/claimtxman.go
@@ -101,8 +101,7 @@ func (tm *ClaimTxManager) updateDepositsStatus(ger *etherman.GlobalExitRoot) err
 	}
 	if ger.BlockID != 0 { // L2 exit root is updated
 		log.Infof("Rollup exitroot %v is updated", ger.ExitRoots[1])
-		// TODO Include networkID as input in UpdateL2DepositsStatus to handle multiple networkIDs in the query
-		if err := tm.storage.UpdateL2DepositsStatus(tm.ctx, ger.ExitRoots[1][:], dbTx); err != nil {
+		if err := tm.storage.UpdateL2DepositsStatus(tm.ctx, ger.ExitRoots[1][:], tm.l2NetworkID, dbTx); err != nil {
 			return err
 		}
 	} else { // L1 exit root is updated in the trusted state

--- a/claimtxman/claimtxman_test.go
+++ b/claimtxman/claimtxman_test.go
@@ -199,3 +199,98 @@ func TestUpdateDepositStatus(t *testing.T) {
 	require.True(t, deposits[1].ReadyForClaim)
 	require.False(t, deposits[0].ReadyForClaim)
 }
+
+func TestUpdateL2DepositStatusMultipleRollups(t *testing.T) {
+	ctx := context.Background()
+	dbCfg := pgstorage.NewConfigFromEnv()
+	err := pgstorage.InitOrReset(dbCfg)
+	require.NoError(t, err)
+	pg, err := pgstorage.NewPostgresStorage(dbCfg)
+	require.NoError(t, err)
+
+	destAdr := "0x4d5Cf5032B2a844602278b01199ED191A86c93ff"
+
+	block1 := &etherman.Block{
+		BlockNumber: 1,
+		BlockHash:   common.HexToHash("0xb4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30"),
+		ParentHash:  common.HexToHash("0xb4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30"),
+		NetworkID:   1,
+		ReceivedAt:  time.Now(),
+	}
+	blockID1, err := pg.AddBlock(ctx, block1, nil)
+	require.NoError(t, err)
+
+	deposit1 := &etherman.Deposit{
+		NetworkID:          1,
+		OriginalNetwork:    0,
+		OriginalAddress:    common.HexToAddress("0x6B175474E89094C44Da98b954EedeAC495271d0F"),
+		Amount:             big.NewInt(1000000),
+		DestinationNetwork: 1,
+		DestinationAddress: common.HexToAddress(destAdr),
+		BlockNumber:        1,
+		BlockID:            blockID1,
+		DepositCount:       1,
+		Metadata:           common.FromHex("0x0"),
+	}
+	depositID1, err := pg.AddDeposit(ctx, deposit1, nil)
+	require.NoError(t, err)
+	l2Root1 := common.FromHex("0xb4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30")
+	require.NoError(t, pg.SetRoot(ctx, l2Root1, depositID1, deposit1.DepositCount, deposit1.NetworkID, nil))
+
+	block2 := &etherman.Block{
+		BlockNumber: 1,
+		BlockHash:   common.HexToHash("0x90c89934975cc71a021a11dbe78cb2008d77e018dfffcc629b8d6d4dc905ac5c"),
+		ParentHash:  common.HexToHash("0x90c89934975cc71a021a11dbe78cb2008d77e018dfffcc629b8d6d4dc905ac5c"),
+		NetworkID:   2,
+		ReceivedAt:  time.Now(),
+	}
+	blockID2, err := pg.AddBlock(ctx, block2, nil)
+	require.NoError(t, err)
+
+	deposit2 := &etherman.Deposit{
+		NetworkID:          2,
+		OriginalNetwork:    0,
+		OriginalAddress:    common.HexToAddress("0x6B175474E89094C44Da98b954EedeAC495271d0F"),
+		Amount:             big.NewInt(1000000),
+		DestinationNetwork: 2,
+		DestinationAddress: common.HexToAddress(destAdr),
+		BlockNumber:        1,
+		BlockID:            blockID2,
+		DepositCount:       1,
+		Metadata:           common.FromHex("0x0"),
+	}
+	depositID2, err := pg.AddDeposit(ctx, deposit2, nil)
+	require.NoError(t, err)
+	l2Root2 := common.FromHex("0x90c89934975cc71a021a11dbe78cb2008d77e018dfffcc629b8d6d4dc905ac5c")
+	require.NoError(t, pg.SetRoot(ctx, l2Root2, depositID2, deposit2.DepositCount, deposit2.NetworkID, nil))
+
+	// This root is for network 1, this won't upgrade anything
+	require.NoError(t, pg.UpdateL2DepositsStatus(ctx, l2Root1, 2, nil))
+	deposits, err := pg.GetDeposits(ctx, destAdr, 10, 0, nil)
+	require.NoError(t, err)
+	require.Len(t, deposits, 2)
+	require.False(t, deposits[1].ReadyForClaim)
+	require.False(t, deposits[0].ReadyForClaim)
+
+	// This root is for network 2, this won't upgrade anything
+	require.NoError(t, pg.UpdateL2DepositsStatus(ctx, l2Root2, 1, nil))
+	deposits, err = pg.GetDeposits(ctx, destAdr, 10, 0, nil)
+	require.NoError(t, err)
+	require.Len(t, deposits, 2)
+	require.False(t, deposits[1].ReadyForClaim)
+	require.False(t, deposits[0].ReadyForClaim)
+
+	require.NoError(t, pg.UpdateL2DepositsStatus(ctx, l2Root1, 1, nil))
+	deposits, err = pg.GetDeposits(ctx, destAdr, 10, 0, nil)
+	require.NoError(t, err)
+	require.Len(t, deposits, 2)
+	require.True(t, deposits[1].ReadyForClaim)
+	require.False(t, deposits[0].ReadyForClaim)
+
+	require.NoError(t, pg.UpdateL2DepositsStatus(ctx, l2Root2, 2, nil))
+	deposits, err = pg.GetDeposits(ctx, destAdr, 10, 0, nil)
+	require.NoError(t, err)
+	require.Len(t, deposits, 2)
+	require.True(t, deposits[1].ReadyForClaim)
+	require.True(t, deposits[0].ReadyForClaim)
+}

--- a/claimtxman/claimtxman_test.go
+++ b/claimtxman/claimtxman_test.go
@@ -192,7 +192,7 @@ func TestUpdateDepositStatus(t *testing.T) {
 	require.Equal(t, deposits[0].DepositCount, uint(1))
 	require.Equal(t, deposits[0].NetworkID, uint(0))
 
-	require.NoError(t, pg.UpdateL2DepositsStatus(ctx, l2Root, nil))
+	require.NoError(t, pg.UpdateL2DepositsStatus(ctx, l2Root, 1, nil))
 	deposits, err = pg.GetDeposits(ctx, destAdr, 10, 0, nil)
 	require.NoError(t, err)
 	require.Len(t, deposits, 2)

--- a/claimtxman/interfaces.go
+++ b/claimtxman/interfaces.go
@@ -12,7 +12,7 @@ import (
 type storageInterface interface {
 	AddBlock(ctx context.Context, block *etherman.Block, dbTx pgx.Tx) (uint64, error)
 	UpdateL1DepositsStatus(ctx context.Context, exitRoot []byte, dbTx pgx.Tx) ([]*etherman.Deposit, error)
-	UpdateL2DepositsStatus(ctx context.Context, exitRoot []byte, dbTx pgx.Tx) error
+	UpdateL2DepositsStatus(ctx context.Context, exitRoot []byte, networkID uint, dbTx pgx.Tx) error
 	AddClaimTx(ctx context.Context, mTx types.MonitoredTx, dbTx pgx.Tx) error
 	UpdateClaimTx(ctx context.Context, mTx types.MonitoredTx, dbTx pgx.Tx) error
 	GetClaimTxsByStatus(ctx context.Context, statuses []types.MonitoredTxStatus, dbTx pgx.Tx) ([]types.MonitoredTx, error)

--- a/db/pgstorage/pgstorage.go
+++ b/db/pgstorage/pgstorage.go
@@ -608,7 +608,7 @@ func (p *PostgresStorage) UpdateL1DepositsStatus(ctx context.Context, exitRoot [
 func (p *PostgresStorage) UpdateL2DepositsStatus(ctx context.Context, exitRoot []byte, networkID uint, dbTx pgx.Tx) error {
 	const updateDepositsStatusSQL = `UPDATE sync.deposit SET ready_for_claim = true
 		WHERE deposit_cnt <=
-			(SELECT deposit_cnt FROM mt.root WHERE root = $1 AND network = 1)
+			(SELECT deposit_cnt FROM mt.root WHERE root = $1 AND network = $2)
 			AND network_id = $2 AND ready_for_claim = false;`
 	_, err := p.getExecQuerier(dbTx).Exec(ctx, updateDepositsStatusSQL, exitRoot, networkID)
 	return err

--- a/db/pgstorage/pgstorage.go
+++ b/db/pgstorage/pgstorage.go
@@ -605,12 +605,12 @@ func (p *PostgresStorage) UpdateL1DepositsStatus(ctx context.Context, exitRoot [
 }
 
 // UpdateL2DepositsStatus updates the ready_for_claim status of L2 deposits.
-func (p *PostgresStorage) UpdateL2DepositsStatus(ctx context.Context, exitRoot []byte, dbTx pgx.Tx) error {
-	const updateDepositsStatusSQL = `UPDATE sync.deposit SET ready_for_claim = true 
+func (p *PostgresStorage) UpdateL2DepositsStatus(ctx context.Context, exitRoot []byte, networkID uint, dbTx pgx.Tx) error {
+	const updateDepositsStatusSQL = `UPDATE sync.deposit SET ready_for_claim = true
 		WHERE deposit_cnt <=
-			(SELECT deposit_cnt FROM mt.root WHERE root = $1 AND network = 1) 
-			AND network_id != 0 AND ready_for_claim = false;`
-	_, err := p.getExecQuerier(dbTx).Exec(ctx, updateDepositsStatusSQL, exitRoot)
+			(SELECT deposit_cnt FROM mt.root WHERE root = $1 AND network = 1)
+			AND network_id = $2 AND ready_for_claim = false;`
+	_, err := p.getExecQuerier(dbTx).Exec(ctx, updateDepositsStatusSQL, exitRoot, networkID)
 	return err
 }
 


### PR DESCRIPTION
Closes #414.

### What does this PR do?

When ClaimTxManager updates a deposit, update the deposit for the specific L2 network ID, so we can support multiple rollups.