### PR TITLE
fix ignore deposit if fails during gasestimation

### DIFF
--- a/claimtxman/claimtxman.go
+++ b/claimtxman/claimtxman.go
@@ -181,6 +181,7 @@ func (tm *ClaimTxManager) updateDepositsStatus(ger *etherman.GlobalExitRoot) err
 	}
 	err = tm.storage.Commit(tm.ctx, dbTx)
 	if err != nil {
+		log.Errorf("AddClaimTx committing dbTx. Err: %v", err)
 		rollbackErr := tm.storage.Rollback(tm.ctx, dbTx)
 		if rollbackErr != nil {
 			log.Fatalf("claimtxman error rolling back state. RollbackErr: %s, err: %s", rollbackErr.Error(), err.Error())


### PR DESCRIPTION
Closes #423 

### What does this PR do?

This PR ignores a deposit if the claim tx fails during the gas estimation. This will avoid the service to be stuck if a user sends a deposit whose claim tx would fail

### Reviewers

- @acroca 