### PR TITLE
Return GlobalIndex in GetBridge

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -372,6 +372,10 @@ func (s *bridgeService) GetBridge(ctx context.Context, req *pb.GetBridgeRequest)
 		return nil, err
 	}
 
+	mainnetFlag := deposit.NetworkID == 0
+	rollupIndex := s.rollupID - 1
+	localExitRootIndex := deposit.DepositCount
+
 	return &pb.GetBridgeResponse{
 		Deposit: &pb.Deposit{
 			LeafType:      uint32(deposit.LeafType),
@@ -387,6 +391,7 @@ func (s *bridgeService) GetBridge(ctx context.Context, req *pb.GetBridgeRequest)
 			ClaimTxHash:   claimTxHash,
 			Metadata:      "0x" + hex.EncodeToString(deposit.Metadata),
 			ReadyForClaim: deposit.ReadyForClaim,
+			GlobalIndex:   etherman.GenerateGlobalIndex(mainnetFlag, rollupIndex, localExitRootIndex).String(),
 		},
 	}, nil
 }


### PR DESCRIPTION
Closes #<issue number>.

### What does this PR do?

Return GlobalIndex in GetBridge to make it consistent with other APIs

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @John
- @Doe

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
