### PR TITLE
feat: implement method to parse default config file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"bytes"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -31,17 +30,11 @@ type Config struct {
 
 // Load loads the configuration
 func Load(configFilePath string, network string) (*Config, error) {
-	var cfg Config
-	viper.SetConfigType("toml")
+	cfg, err := Default()
+	if err != nil {
+		return nil, err
+	}
 
-	err := viper.ReadConfig(bytes.NewBuffer([]byte(DefaultValues)))
-	if err != nil {
-		return nil, err
-	}
-	err = viper.Unmarshal(&cfg, viper.DecodeHook(mapstructure.TextUnmarshallerHookFunc()))
-	if err != nil {
-		return nil, err
-	}
 	if configFilePath != "" {
 		dirName, fileName := filepath.Split(configFilePath)
 
@@ -52,14 +45,14 @@ func Load(configFilePath string, network string) (*Config, error) {
 		viper.SetConfigName(fileNameWithoutExtension)
 		viper.SetConfigType(fileExtension)
 	}
+
 	viper.AutomaticEnv()
 	replacer := strings.NewReplacer(".", "_")
 	viper.SetEnvKeyReplacer(replacer)
 	viper.SetEnvPrefix("ZKEVM_BRIDGE")
-	err = viper.ReadInConfig()
-	if err != nil {
-		_, ok := err.(viper.ConfigFileNotFoundError)
-		if ok {
+
+	if err = viper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			log.Infof("config file not found")
 		} else {
 			log.Infof("error reading config file: ", err)
@@ -67,20 +60,24 @@ func Load(configFilePath string, network string) (*Config, error) {
 		}
 	}
 
-	err = viper.Unmarshal(&cfg, viper.DecodeHook(mapstructure.TextUnmarshallerHookFunc()))
+	decodeHooks := []viper.DecoderConfigOption{
+		// this allows arrays to be decoded from env var separated by ",", example: MY_VAR="value1,value2,value3"
+		viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(mapstructure.TextUnmarshallerHookFunc(), mapstructure.StringToSliceHookFunc(","))),
+	}
+	err = viper.Unmarshal(&cfg, decodeHooks...)
 	if err != nil {
 		return nil, err
 	}
 
 	if viper.IsSet("NetworkConfig") && network != "" {
-		return nil, errors.New("Network details are provided in the config file (the [NetworkConfig] section) and as a flag (the --network or -n). Configure it only once and try again please.")
+		return nil, errors.New("network details are provided in the config file (the [NetworkConfig] section) and as a flag (the --network or -n). Configure it only once and try again please")
 	}
 	if !viper.IsSet("NetworkConfig") && network == "" {
-		return nil, errors.New("Network details are not provided. Please configure the [NetworkConfig] section in your config file, or provide a --network flag.")
+		return nil, errors.New("network details are not provided. Please configure the [NetworkConfig] section in your config file, or provide a --network flag")
 	}
 	if !viper.IsSet("NetworkConfig") && network != "" {
 		cfg.loadNetworkConfig(network)
 	}
 
-	return &cfg, nil
+	return cfg, nil
 }

--- a/config/default.go
+++ b/config/default.go
@@ -1,5 +1,12 @@
 package config
 
+import (
+	"bytes"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/viper"
+)
+
 // DefaultValues is the default configuration
 const DefaultValues = `
 [Log]
@@ -51,3 +58,19 @@ BridgeVersion = "v1"
     Port = "5432"
     MaxConns = 20
 `
+
+// Default parses the default configuration values.
+func Default() (*Config, error) {
+	var cfg Config
+	viper.SetConfigType("toml")
+
+	err := viper.ReadConfig(bytes.NewBuffer([]byte(DefaultValues)))
+	if err != nil {
+		return nil, err
+	}
+	err = viper.Unmarshal(&cfg, viper.DecodeHook(mapstructure.TextUnmarshallerHookFunc()))
+	if err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}


### PR DESCRIPTION
The motivation behind this PR is that we are building a simple tool to dump zkevm-node/cdk-validium components default configuration files. The bridge service is the only one that doesn't implement the `Default() (*Config, error)` method.

Closes #<issue number>.

### What does this PR do?

- Add a `Default() (*Config, error)` method to parse the default configuration values. This method is the same as the one used in [zkevm-node](https://github.com/0xPolygonHermez/zkevm-node/blob/develop/config/config.go#L123) and [agglayer](https://github.com/0xPolygon/agglayer/blob/main/config/default.go#L64).

- Update the implementation of `Load(configFilePath string, network string) (*Config, error)` to use this new `Default` method. The implementation is the same as the one used in [zkevm-node](https://github.com/0xPolygonHermez/zkevm-node/blob/develop/config/config.go#L139) and [agglayer](https://github.com/0xPolygon/agglayer/blob/main/config/config.go#L62).

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @John
- @Doe

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
