### PR TITLE
fix panic. Now, the claimTxManager waits until L1 sync has finished

### DIFF
--- a/claimtxman/claimtxman.go
+++ b/claimtxman/claimtxman.go
@@ -110,7 +110,7 @@ func (tm *ClaimTxManager) Start() {
 				tm.l2Synced = true
 			}
 			if netID == 0 && !tm.l1Synced {
-				log.Info("RollupID: %d, L1 network synced. GERs ready for ClaimTxManager", tm.rollupID)
+				log.Infof("RollupID: %d, L1 network synced. GERs ready for ClaimTxManager", tm.rollupID)
 				tm.l1Synced = true
 			}
 		case ger = <-tm.chExitRootEvent:

--- a/claimtxman/claimtxman.go
+++ b/claimtxman/claimtxman.go
@@ -43,7 +43,7 @@ type ClaimTxManager struct {
 	auth            *bind.TransactOpts
 	rollupID        uint32
 	l2Synced        bool
-	l1Synced		bool
+	l1Synced        bool
 	nonceCache      *NonceCache
 	monitorTxs      types.TxMonitorer
 }

--- a/claimtxman/claimtxman.go
+++ b/claimtxman/claimtxman.go
@@ -43,6 +43,7 @@ type ClaimTxManager struct {
 	auth            *bind.TransactOpts
 	rollupID        uint32
 	l2Synced        bool
+	l1Synced		bool
 	nonceCache      *NonceCache
 	monitorTxs      types.TxMonitorer
 }
@@ -108,8 +109,12 @@ func (tm *ClaimTxManager) Start() {
 				log.Info("NetworkID synced: ", netID)
 				tm.l2Synced = true
 			}
+			if netID == 0 && !tm.l1Synced {
+				log.Info("RollupID: %d, L1 network synced. GERs ready for ClaimTxManager", tm.rollupID)
+				tm.l1Synced = true
+			}
 		case ger = <-tm.chExitRootEvent:
-			if tm.l2Synced {
+			if tm.l2Synced && tm.l1Synced {
 				log.Debugf("RollupID: %d UpdateDepositsStatus for ger: %s", tm.rollupID, ger.GlobalExitRoot.String())
 				if tm.cfg.GroupingClaims.Enabled {
 					log.Debugf("rollupID: %d, Ger value updated and ready to be processed...", tm.rollupID)
@@ -125,7 +130,7 @@ func (tm *ClaimTxManager) Start() {
 				log.Infof("Waiting for networkID %d to be synced before processing deposits", tm.l2NetworkID)
 			}
 		case <-compressorTicker.C:
-			if tm.l2Synced && tm.cfg.GroupingClaims.Enabled && ger.GlobalExitRoot != latestProcessedGer {
+			if tm.l2Synced && tm.l1Synced && tm.cfg.GroupingClaims.Enabled && ger.GlobalExitRoot != latestProcessedGer {
 				log.Infof("RollupID: %d,Processing deposits for ger: %s", tm.rollupID, ger.GlobalExitRoot.String())
 				go func() {
 					err := tm.updateDepositsStatus(ger)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -113,7 +113,10 @@ func start(ctx *cli.Context) error {
 		for {
 			select {
 			case netID := <-chSynced:
-				log.Debug("NetworkID synced: ", netID)
+				log.Debug("L1 Network synced. NetowrkID: ", netID)
+				for _, ch := range chsSyncedL2 {
+					ch <- netID
+				}
 			case <-ctx.Done():
 				log.Debug("Stopping goroutine that listen new GER updates")
 				return


### PR DESCRIPTION
Closes #744

### What does this PR do?

Fixes the panic when the claimTxManager receives a ger without mainnetexitroot and rollupexitroot. Now the claimTxManager waits until L1 synced has finished
