### PR TITLE
fix(e2e): fix for waittobemined func in e2e

### DIFF
--- a/test/e2e/bridge_network_erc20_test.go
+++ b/test/e2e/bridge_network_erc20_test.go
@@ -146,6 +146,6 @@ func assetERC20Generic(ctx context.Context, client *utils.Client, destNetwork ui
 		return common.Hash{}, err
 	}
 	fmt.Println("Tx: ", tx.Hash().Hex())
-	err = WaitTxToBeMined(ctx, client.Client, tx, 60*time.Second)
+	err = operations.WaitTxToBeMined(ctx, client.Client, tx, 60*time.Second)
 	return tx.Hash(), err
 }


### PR DESCRIPTION
Closes #<issue number>.

### What does this PR do?

FIx for the e2e test `bridge_network_erc20_test.go` WaitToBeMined func that got dereferenced in the cherrypick [a1f63c7
](https://github.com/0xPolygonHermez/zkevm-bridge-service/commit/a1f63c7d6b6d15a7e5a2f9c2a7a05a862049b1b5)

Found from cdk-erigon failing tests

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @John
- @Doe

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
