### PR TITLE
rollback mt.count

### DIFF
--- a/bridgectrl/bridgectrl.go
+++ b/bridgectrl/bridgectrl.go
@@ -58,13 +58,13 @@ func (bt *BridgeController) GetMerkleTreeID(networkID uint32) (uint8, error) {
 }
 
 // AddDeposit adds deposit information to the bridge tree.
-func (bt *BridgeController) AddDeposit(ctx context.Context, deposit *etherman.Deposit, depositID uint64, dbTx interface{}) error {
+func (bt *BridgeController) AddDeposit(ctx context.Context, deposit *etherman.Deposit, dbTx interface{}) error {
 	leaf := hashDeposit(deposit)
 	tID, err := bt.GetMerkleTreeID(deposit.NetworkID)
 	if err != nil {
 		return err
 	}
-	return bt.exitTrees[tID].addLeaf(ctx, depositID, leaf, deposit.DepositCount, dbTx)
+	return bt.exitTrees[tID].addLeaf(ctx, deposit.Id, leaf, deposit.DepositCount, dbTx)
 }
 
 // ReorgMT reorg the specific merkle tree.

--- a/bridgectrl/bridgectrl.go
+++ b/bridgectrl/bridgectrl.go
@@ -76,6 +76,15 @@ func (bt *BridgeController) ReorgMT(ctx context.Context, depositCount uint32, ne
 	return bt.exitTrees[tID].resetLeaf(ctx, depositCount, dbTx)
 }
 
+// RollbackMT resets the specific merkle tree.
+func (bt *BridgeController) RollbackMT(ctx context.Context, networkID uint32, dbTx interface{}) error {
+	tID, err := bt.GetMerkleTreeID(networkID)
+	if err != nil {
+		return err
+	}
+	return bt.exitTrees[tID].rollbackMT(ctx, networkID, dbTx)
+}
+
 // GetExitRoot returns the dedicated merkle tree's root.
 // only use for the test purpose
 func (bt *BridgeController) GetExitRoot(ctx context.Context, tID uint8, dbTx interface{}) ([]byte, error) {

--- a/bridgectrl/bridgectrl_test.go
+++ b/bridgectrl/bridgectrl_test.go
@@ -78,7 +78,8 @@ func TestBridgeTree(t *testing.T) {
 			assert.Equal(t, testVector.ExpectedHash, hex.EncodeToString(leafHash[:]))
 			depositID, err := testStore.AddDeposit(ctx, deposit, nil)
 			require.NoError(t, err)
-			err = bt.AddDeposit(ctx, deposit, depositID, nil)
+			deposit.Id = depositID
+			err = bt.AddDeposit(ctx, deposit, nil)
 			require.NoError(t, err)
 
 			// test reorg
@@ -92,7 +93,8 @@ func TestBridgeTree(t *testing.T) {
 			deposit.BlockID = blockID
 			depositID, err = testStore.AddDeposit(ctx, deposit, nil)
 			require.NoError(t, err)
-			err = bt.AddDeposit(ctx, deposit, depositID, nil)
+			deposit.Id = depositID
+			err = bt.AddDeposit(ctx, deposit, nil)
 			require.NoError(t, err)
 			newRoot, err := bt.exitTrees[0].store.GetRoot(ctx, uint32(i), 0, nil) // nolint:gosec
 			require.NoError(t, err)

--- a/bridgectrl/merkletree.go
+++ b/bridgectrl/merkletree.go
@@ -163,6 +163,21 @@ func (mt *MerkleTree) resetLeaf(ctx context.Context, depositCount uint32, dbTx i
 	return err
 }
 
+func (mt *MerkleTree) rollbackMT(ctx context.Context, networkID uint32, dbTx interface{}) error {
+	depositCnt, err := mt.store.GetLastDepositCount(ctx, networkID, nil)
+	if err != nil {
+		if err != gerror.ErrStorageNotFound {
+			return err
+		}
+		depositCnt = 0
+	} else {
+		depositCnt++
+	}
+	mt.count = depositCnt
+	mt.siblings, err = mt.initSiblings(ctx, dbTx)
+	return err
+}
+
 // this function is used to get the current root of the merkle tree
 func (mt *MerkleTree) getRoot(ctx context.Context, dbTx interface{}) ([]byte, error) {
 	if mt.count == 0 {

--- a/synchronizer/interfaces.go
+++ b/synchronizer/interfaces.go
@@ -43,6 +43,7 @@ type storageInterface interface {
 type bridgectrlInterface interface {
 	AddDeposit(ctx context.Context, deposit *etherman.Deposit, depositID uint64, dbTx interface{}) error
 	ReorgMT(ctx context.Context, depositCount, networkID uint32, dbTx interface{}) error
+	RollbackMT(ctx context.Context, networkID uint32, dbTx interface{}) error
 	AddRollupExitLeaf(ctx context.Context, rollupLeaf etherman.RollupExitLeaf, dbTx interface{}) error
 }
 

--- a/synchronizer/interfaces.go
+++ b/synchronizer/interfaces.go
@@ -41,7 +41,7 @@ type storageInterface interface {
 }
 
 type bridgectrlInterface interface {
-	AddDeposit(ctx context.Context, deposit *etherman.Deposit, depositID uint64, dbTx interface{}) error
+	AddDeposit(ctx context.Context, deposit *etherman.Deposit, dbTx interface{}) error
 	ReorgMT(ctx context.Context, depositCount, networkID uint32, dbTx interface{}) error
 	RollbackMT(ctx context.Context, networkID uint32, dbTx interface{}) error
 	AddRollupExitLeaf(ctx context.Context, rollupLeaf etherman.RollupExitLeaf, dbTx interface{}) error

--- a/synchronizer/mock_bridgectrl.go
+++ b/synchronizer/mock_bridgectrl.go
@@ -22,17 +22,17 @@ func (_m *bridgectrlMock) EXPECT() *bridgectrlMock_Expecter {
 	return &bridgectrlMock_Expecter{mock: &_m.Mock}
 }
 
-// AddDeposit provides a mock function with given fields: ctx, deposit, depositID, dbTx
-func (_m *bridgectrlMock) AddDeposit(ctx context.Context, deposit *etherman.Deposit, depositID uint64, dbTx interface{}) error {
-	ret := _m.Called(ctx, deposit, depositID, dbTx)
+// AddDeposit provides a mock function with given fields: ctx, deposit, dbTx
+func (_m *bridgectrlMock) AddDeposit(ctx context.Context, deposit *etherman.Deposit, dbTx interface{}) error {
+	ret := _m.Called(ctx, deposit, dbTx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AddDeposit")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *etherman.Deposit, uint64, interface{}) error); ok {
-		r0 = rf(ctx, deposit, depositID, dbTx)
+	if rf, ok := ret.Get(0).(func(context.Context, *etherman.Deposit, interface{}) error); ok {
+		r0 = rf(ctx, deposit, dbTx)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -48,15 +48,14 @@ type bridgectrlMock_AddDeposit_Call struct {
 // AddDeposit is a helper method to define mock.On call
 //   - ctx context.Context
 //   - deposit *etherman.Deposit
-//   - depositID uint64
 //   - dbTx interface{}
-func (_e *bridgectrlMock_Expecter) AddDeposit(ctx interface{}, deposit interface{}, depositID interface{}, dbTx interface{}) *bridgectrlMock_AddDeposit_Call {
-	return &bridgectrlMock_AddDeposit_Call{Call: _e.mock.On("AddDeposit", ctx, deposit, depositID, dbTx)}
+func (_e *bridgectrlMock_Expecter) AddDeposit(ctx interface{}, deposit interface{}, dbTx interface{}) *bridgectrlMock_AddDeposit_Call {
+	return &bridgectrlMock_AddDeposit_Call{Call: _e.mock.On("AddDeposit", ctx, deposit, dbTx)}
 }
 
-func (_c *bridgectrlMock_AddDeposit_Call) Run(run func(ctx context.Context, deposit *etherman.Deposit, depositID uint64, dbTx interface{})) *bridgectrlMock_AddDeposit_Call {
+func (_c *bridgectrlMock_AddDeposit_Call) Run(run func(ctx context.Context, deposit *etherman.Deposit, dbTx interface{})) *bridgectrlMock_AddDeposit_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*etherman.Deposit), args[2].(uint64), args[3].(interface{}))
+		run(args[0].(context.Context), args[1].(*etherman.Deposit), args[2].(interface{}))
 	})
 	return _c
 }
@@ -66,7 +65,7 @@ func (_c *bridgectrlMock_AddDeposit_Call) Return(_a0 error) *bridgectrlMock_AddD
 	return _c
 }
 
-func (_c *bridgectrlMock_AddDeposit_Call) RunAndReturn(run func(context.Context, *etherman.Deposit, uint64, interface{}) error) *bridgectrlMock_AddDeposit_Call {
+func (_c *bridgectrlMock_AddDeposit_Call) RunAndReturn(run func(context.Context, *etherman.Deposit, interface{}) error) *bridgectrlMock_AddDeposit_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/synchronizer/mock_bridgectrl.go
+++ b/synchronizer/mock_bridgectrl.go
@@ -168,6 +168,54 @@ func (_c *bridgectrlMock_ReorgMT_Call) RunAndReturn(run func(context.Context, ui
 	return _c
 }
 
+// RollbackMT provides a mock function with given fields: ctx, networkID, dbTx
+func (_m *bridgectrlMock) RollbackMT(ctx context.Context, networkID uint32, dbTx interface{}) error {
+	ret := _m.Called(ctx, networkID, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RollbackMT")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, interface{}) error); ok {
+		r0 = rf(ctx, networkID, dbTx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// bridgectrlMock_RollbackMT_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RollbackMT'
+type bridgectrlMock_RollbackMT_Call struct {
+	*mock.Call
+}
+
+// RollbackMT is a helper method to define mock.On call
+//   - ctx context.Context
+//   - networkID uint32
+//   - dbTx interface{}
+func (_e *bridgectrlMock_Expecter) RollbackMT(ctx interface{}, networkID interface{}, dbTx interface{}) *bridgectrlMock_RollbackMT_Call {
+	return &bridgectrlMock_RollbackMT_Call{Call: _e.mock.On("RollbackMT", ctx, networkID, dbTx)}
+}
+
+func (_c *bridgectrlMock_RollbackMT_Call) Run(run func(ctx context.Context, networkID uint32, dbTx interface{})) *bridgectrlMock_RollbackMT_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(uint32), args[2].(interface{}))
+	})
+	return _c
+}
+
+func (_c *bridgectrlMock_RollbackMT_Call) Return(_a0 error) *bridgectrlMock_RollbackMT_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *bridgectrlMock_RollbackMT_Call) RunAndReturn(run func(context.Context, uint32, interface{}) error) *bridgectrlMock_RollbackMT_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // newBridgectrlMock creates a new instance of bridgectrlMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func newBridgectrlMock(t interface {

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -765,7 +765,7 @@ func (s *ClientSynchronizer) processDeposit(deposit etherman.Deposit, blockID ui
 		return s.rollback(deposit.BlockNumber, err, dbTx)
 	}
 	deposit.Id = depositID
-	err = s.bridgeCtrl.AddDeposit(s.ctx, &deposit, depositID, dbTx)
+	err = s.bridgeCtrl.AddDeposit(s.ctx, &deposit, dbTx)
 	if err != nil {
 		log.Errorf("networkID: %d, failed to store new deposit in the bridge tree, BlockNumber: %d, Deposit: %+v err: %v", s.networkID, deposit.BlockNumber, deposit, err)
 		return s.rollback(deposit.BlockNumber, err, dbTx)

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -456,13 +456,7 @@ func (s *ClientSynchronizer) processBlockRange(blocks []etherman.Block, order ma
 		blockID, err := s.storage.AddBlock(s.ctx, &blocks[i], dbTx)
 		if err != nil {
 			log.Errorf("networkID: %d, error storing block. BlockNumber: %d, error: %v", s.networkID, blocks[i].BlockNumber, err)
-			rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-			if rollbackErr != nil {
-				log.Errorf("networkID: %d, error rolling back state to store block. BlockNumber: %d, rollbackErr: %v, err: %s",
-					s.networkID, blocks[i].BlockNumber, rollbackErr, err.Error())
-				return rollbackErr
-			}
-			return err
+			return s.rollback(blocks[i].BlockNumber, err, dbTx)
 		}
 		for _, element := range order[blocks[i].BlockHash] {
 			switch element.Name {
@@ -534,13 +528,7 @@ func (s *ClientSynchronizer) processBlockRange(blocks []etherman.Block, order ma
 		if err != nil {
 			log.Errorf("networkID: %d, error committing state to store block. BlockNumber: %d, err: %v",
 				s.networkID, blocks[i].BlockNumber, err)
-			rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-			if rollbackErr != nil {
-				log.Errorf("networkID: %d, error rolling back state. BlockNumber: %d, rollbackErr: %v, err: %s",
-					s.networkID, blocks[i].BlockNumber, rollbackErr, err.Error())
-				return rollbackErr
-			}
-			return err
+			return s.rollback(blocks[i].BlockNumber, err, dbTx)
 		}
 	}
 	if isNewL1Ger {
@@ -582,47 +570,23 @@ func (s *ClientSynchronizer) resetState(blockNumber uint64) error {
 	err = s.storage.Reset(s.ctx, blockNumber, s.networkID, dbTx)
 	if err != nil {
 		log.Errorf("networkID: %d, error resetting the state. Error: %v", s.networkID, err)
-		rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-		if rollbackErr != nil {
-			log.Errorf("networkID: %d, error rolling back state to store block. BlockNumber: %d, rollbackErr: %v, error : %s",
-				s.networkID, blockNumber, rollbackErr, err.Error())
-			return rollbackErr
-		}
-		return err
+		return s.rollback(blockNumber, err, dbTx)
 	}
 	depositCnt, err := s.storage.GetNumberDeposits(s.ctx, s.networkID, blockNumber, dbTx)
 	if err != nil {
 		log.Errorf("networkID: %d, error getting GetNumberDeposits. Error: %v", s.networkID, err)
-		rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-		if rollbackErr != nil {
-			log.Errorf("networkID: %d, error rolling back state to store block. BlockNumber: %d, rollbackErr: %v, error : %s",
-				s.networkID, blockNumber, rollbackErr, err.Error())
-			return rollbackErr
-		}
-		return err
+		return s.rollback(blockNumber, err, dbTx)
 	}
 
 	err = s.bridgeCtrl.ReorgMT(s.ctx, depositCnt, s.networkID, dbTx)
 	if err != nil {
 		log.Errorf("networkID: %d, error resetting ReorgMT the state. Error: %v", s.networkID, err)
-		rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-		if rollbackErr != nil {
-			log.Errorf("networkID: %d, error rolling back state to store block. BlockNumber: %d, rollbackErr: %v, error : %s",
-				s.networkID, blockNumber, rollbackErr, err.Error())
-			return rollbackErr
-		}
-		return err
+		return s.rollback(blockNumber, err, dbTx)
 	}
 	err = s.storage.Commit(s.ctx, dbTx)
 	if err != nil {
 		log.Errorf("networkID: %d, error committing the resetted state. Error: %v", s.networkID, err)
-		rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-		if rollbackErr != nil {
-			log.Errorf("networkID: %d, error rolling back state to store block. BlockNumber: %d, rollbackErr: %v, error : %s",
-				s.networkID, blockNumber, rollbackErr, err.Error())
-			return rollbackErr
-		}
-		return err
+		return s.rollback(blockNumber, err, dbTx)
 	}
 
 	return nil
@@ -717,23 +681,15 @@ func (s *ClientSynchronizer) processVerifyBatch(verifyBatch etherman.VerifiedBat
 		ok, err := s.storage.CheckIfRootExists(s.ctx, verifyBatch.LocalExitRoot.Bytes(), verifyBatch.RollupID, dbTx)
 		if err != nil {
 			log.Errorf("networkID: %d, error Checking if root exists. Error: %v", s.networkID, err)
-			rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-			if rollbackErr != nil {
-				log.Errorf("networkID: %d, error rolling back state. BlockNumber: %d, rollbackErr: %v, error : %s",
-					s.networkID, verifyBatch.BlockNumber, rollbackErr, err.Error())
-				return rollbackErr
-			}
-			return err
+			return s.rollback(verifyBatch.BlockNumber, err, dbTx)
 		}
 		if !ok {
-			log.Errorf("networkID: %d, Root: %s doesn't exist!", s.networkID, verifyBatch.LocalExitRoot.String())
-			rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-			if rollbackErr != nil {
-				log.Errorf("networkID: %d, error rolling back state. BlockNumber: %d, rollbackErr: %v",
-					s.networkID, verifyBatch.BlockNumber, rollbackErr)
-				return rollbackErr
+			if s.synced {
+				log.Errorf("networkID: %d, Root: %s doesn't exist!", s.networkID, verifyBatch.LocalExitRoot.String())
+			} else {
+				log.Infof("NetworkID: %d, Root: %s doesn't found yet. Retrying...", s.networkID, verifyBatch.LocalExitRoot.String())
 			}
-			return fmt.Errorf("networkID: %d, Root: %s doesn't exist!", s.networkID, verifyBatch.LocalExitRoot.String())
+			return s.rollback(verifyBatch.BlockNumber, fmt.Errorf("networkID: %d, Root: %s doesn't exist!", s.networkID, verifyBatch.LocalExitRoot.String()), dbTx)
 		}
 	}
 	rollupLeaf := etherman.RollupExitLeaf{
@@ -745,13 +701,7 @@ func (s *ClientSynchronizer) processVerifyBatch(verifyBatch etherman.VerifiedBat
 	err := s.bridgeCtrl.AddRollupExitLeaf(s.ctx, rollupLeaf, dbTx)
 	if err != nil {
 		log.Errorf("networkID: %d, error adding rollup exit leaf. Error: %v", s.networkID, err)
-		rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-		if rollbackErr != nil {
-			log.Errorf("networkID: %d, error rolling back state. BlockNumber: %d, rollbackErr: %v, error : %s",
-				s.networkID, verifyBatch.BlockNumber, rollbackErr, err.Error())
-			return rollbackErr
-		}
-		return err
+		return s.rollback(verifyBatch.BlockNumber, err, dbTx)
 	}
 	return nil
 }
@@ -761,44 +711,26 @@ func (s *ClientSynchronizer) processGlobalExitRoot(globalExitRoot etherman.Globa
 	globalExitRoot.BlockID = blockID
 	globalExitRoot.NetworkID = s.networkID
 	if len(globalExitRoot.ExitRoots) == 2 { //nolint:mnd
-		log.Debugf("networkID: %d, Storing L1 Ger: %s", s.networkID, globalExitRoot.GlobalExitRoot.String())
+		log.Debugf("NetworkID: %d, Storing L1 Ger: %s", s.networkID, globalExitRoot.GlobalExitRoot.String())
 		// Check if there is some globalExitRoot in L2. If so, it must be incompleted. It must be updated.
 		// A race condition between dbTxs (L1 dbTx and L2 dbTxs) is very unlikely because L1 sync takes usually takes more time than L2 sync.
 		gers, err := s.storage.GetL2ExitRootsByGER(s.ctx, globalExitRoot.GlobalExitRoot, nil)
 		if err != nil && !errors.Is(err, gerror.ErrStorageNotFound) {
 			log.Errorf("networkID: %d, error reading L2ExitRootsByGER in processGlobalExitRoot. BlockNumber: %d. Error: %v", s.networkID, globalExitRoot.BlockNumber, err)
-			rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-			if rollbackErr != nil {
-				log.Errorf("networkID: %d, error rolling back state. BlockNumber: %d, rollbackErr: %v, error : %s",
-					s.networkID, globalExitRoot.BlockNumber, rollbackErr, err.Error())
-				return rollbackErr
-			}
-			return err
+			return s.rollback(globalExitRoot.BlockNumber, err, dbTx)
 		}
 		for _, ger := range gers {
 			ger.ExitRoots = globalExitRoot.ExitRoots
 			err = s.storage.UpdateL2GER(s.ctx, ger, dbTx)
 			if err != nil {
 				log.Errorf("networkID: %d, error storing the GlobalExitRoot updated in processGlobalExitRoot. BlockNumber: %d. Error: %v", s.networkID, globalExitRoot.BlockNumber, err)
-				rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-				if rollbackErr != nil {
-					log.Errorf("networkID: %d, error rolling back state. BlockNumber: %d, rollbackErr: %v, error : %s",
-						s.networkID, globalExitRoot.BlockNumber, rollbackErr, err.Error())
-					return rollbackErr
-				}
-				return err
+				return s.rollback(globalExitRoot.BlockNumber, err, dbTx)
 			}
 		}
 		err = s.storage.AddGlobalExitRoot(s.ctx, &globalExitRoot, dbTx)
 		if err != nil {
 			log.Errorf("networkID: %d, error storing the GlobalExitRoot in processGlobalExitRoot. BlockNumber: %d. Error: %v", s.networkID, globalExitRoot.BlockNumber, err)
-			rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-			if rollbackErr != nil {
-				log.Errorf("networkID: %d, error rolling back state. BlockNumber: %d, rollbackErr: %v, error : %s",
-					s.networkID, globalExitRoot.BlockNumber, rollbackErr, err.Error())
-				return rollbackErr
-			}
-			return err
+			return s.rollback(globalExitRoot.BlockNumber, err, dbTx)
 		}
 	} else if len(globalExitRoot.ExitRoots) == 0 {
 		log.Debugf("networkID: %d, Storing L2 Ger: %s", s.networkID, globalExitRoot.GlobalExitRoot)
@@ -808,13 +740,7 @@ func (s *ClientSynchronizer) processGlobalExitRoot(globalExitRoot etherman.Globa
 			log.Warnf("networkID: %d, L1Ger entry not found in the database. GER: %s", s.networkID, globalExitRoot.GlobalExitRoot.String())
 		} else if err != nil {
 			log.Errorf("networkID: %d, error getting the GlobalExitRoot in processGlobalExitRoot. BlockNumber: %d. Error: %v", s.networkID, globalExitRoot.BlockNumber, err)
-			rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-			if rollbackErr != nil {
-				log.Errorf("networkID: %d, error rolling back state. BlockNumber: %d, rollbackErr: %v, error : %s",
-					s.networkID, globalExitRoot.BlockNumber, rollbackErr, err.Error())
-				return rollbackErr
-			}
-			return err
+			return s.rollback(globalExitRoot.BlockNumber, err, dbTx)
 		} else {
 			globalExitRoot.ExitRoots = ger.ExitRoots
 		}
@@ -822,13 +748,7 @@ func (s *ClientSynchronizer) processGlobalExitRoot(globalExitRoot etherman.Globa
 		err = s.storage.AddGlobalExitRoot(s.ctx, &globalExitRoot, dbTx)
 		if err != nil {
 			log.Errorf("networkID: %d, error storing the GlobalExitRoot in processGlobalExitRoot. BlockNumber: %d. Error: %v", s.networkID, globalExitRoot.BlockNumber, err)
-			rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-			if rollbackErr != nil {
-				log.Errorf("networkID: %d, error rolling back state. BlockNumber: %d, rollbackErr: %v, error : %s",
-					s.networkID, globalExitRoot.BlockNumber, rollbackErr, err.Error())
-				return rollbackErr
-			}
-			return err
+			return s.rollback(globalExitRoot.BlockNumber, err, dbTx)
 		}
 	} else {
 		return fmt.Errorf("networkID: %d, error exitRoots have a wrong length. Length: %d", s.networkID, len(globalExitRoot.ExitRoots))
@@ -842,25 +762,13 @@ func (s *ClientSynchronizer) processDeposit(deposit etherman.Deposit, blockID ui
 	depositID, err := s.storage.AddDeposit(s.ctx, &deposit, dbTx)
 	if err != nil {
 		log.Errorf("networkID: %d, failed to store new deposit locally, BlockNumber: %d, Deposit: %+v err: %v", s.networkID, deposit.BlockNumber, deposit, err)
-		rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-		if rollbackErr != nil {
-			log.Errorf("networkID: %d, error rolling back state to store block. BlockNumber: %v, rollbackErr: %v, err: %s",
-				s.networkID, deposit.BlockNumber, rollbackErr, err.Error())
-			return rollbackErr
-		}
-		return err
+		return s.rollback(deposit.BlockNumber, err, dbTx)
 	}
-
+	deposit.Id = depositID
 	err = s.bridgeCtrl.AddDeposit(s.ctx, &deposit, depositID, dbTx)
 	if err != nil {
 		log.Errorf("networkID: %d, failed to store new deposit in the bridge tree, BlockNumber: %d, Deposit: %+v err: %v", s.networkID, deposit.BlockNumber, deposit, err)
-		rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-		if rollbackErr != nil {
-			log.Errorf("networkID: %d, error rolling back state to store block. BlockNumber: %v, rollbackErr: %v, err: %s",
-				s.networkID, deposit.BlockNumber, rollbackErr, err.Error())
-			return rollbackErr
-		}
-		return err
+		return s.rollback(deposit.BlockNumber, err, dbTx)
 	}
 	metrics.DepositAmount(deposit.Amount)
 	return nil
@@ -872,13 +780,7 @@ func (s *ClientSynchronizer) processClaim(claim etherman.Claim, blockID uint64, 
 	err := s.storage.AddClaim(s.ctx, &claim, dbTx)
 	if err != nil {
 		log.Errorf("networkID: %d, error storing new Claim in Block:  %d, Claim: %+v, err: %v", s.networkID, claim.BlockNumber, claim, err)
-		rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-		if rollbackErr != nil {
-			log.Errorf("networkID: %d, error rolling back state to store block. BlockNumber: %d, rollbackErr: %v, err: %s",
-				s.networkID, claim.BlockNumber, rollbackErr, err.Error())
-			return rollbackErr
-		}
-		return err
+		return s.rollback(claim.BlockNumber, err, dbTx)
 	}
 	metrics.ClaimAmount(claim.Amount)
 	return nil
@@ -890,13 +792,7 @@ func (s *ClientSynchronizer) processTokenWrapped(tokenWrapped etherman.TokenWrap
 	err := s.storage.AddTokenWrapped(s.ctx, &tokenWrapped, dbTx)
 	if err != nil {
 		log.Errorf("networkID: %d, error storing new L1 TokenWrapped in Block:  %d, TokenWrapped: %+v, err: %v", s.networkID, tokenWrapped.BlockNumber, tokenWrapped, err)
-		rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-		if rollbackErr != nil {
-			log.Errorf("networkID: %d, error rolling back state to store block. BlockNumber: %d, rollbackErr: %v, err: %s",
-				s.networkID, tokenWrapped.BlockNumber, rollbackErr, err.Error())
-			return rollbackErr
-		}
-		return err
+		return s.rollback(tokenWrapped.BlockNumber, err, dbTx)
 	}
 	metrics.WrappedTokensCounter()
 	return nil
@@ -908,13 +804,24 @@ func (s *ClientSynchronizer) processRemoveL2GlobalExitRoot(ger etherman.GlobalEx
 	err := s.storage.AddRemoveL2GER(s.ctx, ger, dbTx)
 	if err != nil {
 		log.Errorf("networkID: %d, error storing removeL2Ger in Block:  %d, GER: %+v, err: %v", s.networkID, ger.BlockNumber, ger, err)
-		rollbackErr := s.storage.Rollback(s.ctx, dbTx)
-		if rollbackErr != nil {
-			log.Errorf("networkID: %d, error rolling back state to store block. BlockNumber: %d, rollbackErr: %v, err: %s",
-				s.networkID, ger.BlockNumber, rollbackErr, err.Error())
-			return rollbackErr
-		}
-		return err
+		return s.rollback(ger.BlockNumber, err, dbTx)
 	}
 	return nil
+}
+
+func (s *ClientSynchronizer) rollback(blockNumber uint64, err error, dbTx interface{}) error {
+	log.Debug("networkID: ", s.networkID, ", Rolling back the MT. BlockNumber: ", blockNumber)
+	mtErr := s.bridgeCtrl.RollbackMT(s.ctx, s.networkID, nil)
+	for mtErr != nil {
+		log.Errorf("networkID: %d, error rolling back the Merkle tree. BlockNumber: %d, mtErr: %v, err: %s", s.networkID, blockNumber, mtErr, err.Error())
+		mtErr = s.bridgeCtrl.RollbackMT(s.ctx, s.networkID, nil)
+	}
+	log.Debug("networkID: ", s.networkID, ", Rolling back the state. BlockNumber: ", blockNumber)
+	rollbackErr := s.storage.Rollback(s.ctx, dbTx)
+	if rollbackErr != nil {
+		log.Errorf("networkID: %d, error rolling back the state. BlockNumber: %d, rollbackErr: %v, err: %s",
+			s.networkID, blockNumber, rollbackErr, err.Error())
+		return rollbackErr
+	}
+	return err
 }

--- a/test/benchmark/api_test.go
+++ b/test/benchmark/api_test.go
@@ -87,7 +87,8 @@ func initServer(b *testing.B, bench benchmark) *bridgectrl.BridgeController {
 		counts[networkID]++
 		depositID, err := store.AddDeposit(context.TODO(), deposit, dbTx)
 		require.NoError(b, err)
-		require.NoError(b, bt.AddDeposit(ctx, deposit, depositID, dbTx))
+		deposit.Id = depositID
+		require.NoError(b, bt.AddDeposit(ctx, deposit, dbTx))
 		if i > bench.initSize {
 			require.NoError(b, store.Commit(context.TODO(), dbTx))
 			continue
@@ -139,22 +140,19 @@ func addDeposit(b *testing.B, bench benchmark) {
 	r := rand.New(rand.NewSource(bench.seed)) //nolint: gosec
 	bt, store, err := operations.RunMockServer(bench.store, bench.mtHeight, networks)
 	require.NoError(b, err)
-	var (
-		deposits   []*etherman.Deposit
-		depositIDs []uint64
-	)
+	var deposits []*etherman.Deposit
 	for i := 0; i < bench.initSize; i++ {
 		deposit := randDeposit(r, uint32(i), 0, 0) // nolint:gosec
 		depositID, err := store.AddDeposit(context.TODO(), deposit, nil)
 		require.NoError(b, err)
+		deposit.Id = depositID
 		deposits = append(deposits, deposit)
-		depositIDs = append(depositIDs, depositID)
 	}
 	b.StartTimer()
 	for i := 0; i < bench.initSize; i++ {
 		dbTx, err := store.BeginDBTransaction(context.Background())
 		require.NoError(b, err)
-		require.NoError(b, bt.AddDeposit(ctx, deposits[i], depositIDs[i], dbTx))
+		require.NoError(b, bt.AddDeposit(ctx, deposits[i], dbTx))
 		require.NoError(b, store.Commit(context.TODO(), dbTx))
 	}
 }


### PR DESCRIPTION
Closes #806 

### What does this PR do?

This PR fixes the flow where a block that contained a deposit is rollbacked. The mt.count was not being updated and its value was the right one + the number of rollbacked deposits in the block. Now the value is fixed + the siblings.

