### PR TITLE
Fix prometheus metrics

### DIFF
--- a/synchronizer/metrics/metrics.go
+++ b/synchronizer/metrics/metrics.go
@@ -73,6 +73,9 @@ const (
 
 	// LatestBlockSyncedName is the name of the label to get the latest block synced.
 	LatestBlockSyncedName = "latest_block_synced"
+
+	// LatestBlockRollupInfoName is the name of the label to get the latest block rollup info.
+	LatestBlockRollupInfoName = "latest_block_rollup_info"
 )
 
 var (
@@ -81,6 +84,7 @@ var (
 
 type MetricsInterface interface {
 	LatestBlockSynced(blockNumber uint64)
+	LatestBlockRollupInfo(blockNumber uint64)
 	IncrementsPendingBridgesToClaim()
 	DecrementsPendingBridgesToClaim()
 	DepositAmount(amount *big.Int)
@@ -123,6 +127,10 @@ func Register(networkID uint32) MetricsInterface {
 		{
 			Name: prefix + LatestBlockSyncedName,
 			Help: "[SYNCHRONIZER] latest block synced",
+		},
+		{
+			Name: prefix + LatestBlockRollupInfoName,
+			Help: "[SYNCHRONIZER] latest block rollup info",
 		},
 	}
 	counters := []prometheus.CounterOpts{
@@ -219,6 +227,12 @@ func Register(networkID uint32) MetricsInterface {
 func (m *Metrics) LatestBlockSynced(blockNumber uint64) {
 	// Be careful, this uint64 to float64 converion can overflow
 	metrics.GaugeSet(m.prefix+LatestBlockSyncedName, float64(blockNumber))
+}
+
+// LatestBlockRollupInfo sets the latest block rollup info on the gauge.
+func (m *Metrics) LatestBlockRollupInfo(blockNumber uint64) {
+	// Be careful, this uint64 to float64 converion can overflow
+	metrics.GaugeSet(m.prefix+LatestBlockRollupInfoName, float64(blockNumber))
 }
 
 // IncrementsPendingBridgesToClaim increments the current pending bridges to claim on the gauge.

--- a/synchronizer/metrics/metrics.go
+++ b/synchronizer/metrics/metrics.go
@@ -76,104 +76,132 @@ const (
 )
 
 var (
-	Prefix        string
 	registerMutex sync.Mutex
 )
 
+type MetricsInterface interface {
+	LatestBlockSynced(blockNumber uint64)
+	IncrementsPendingBridgesToClaim()
+	DecrementsPendingBridgesToClaim()
+	DepositAmount(amount *big.Int)
+	ClaimAmount(amount *big.Int)
+	InitializationTime(lastProcessTime time.Duration)
+	FullTrustedSyncTime(lastProcessTime time.Duration)
+	FullL1SyncTime(lastProcessTime time.Duration)
+	FullSyncIterationTime(lastProcessTime time.Duration)
+	ReadL1DataTime(lastProcessTime time.Duration)
+	ProcessL1DataTime(lastProcessTime time.Duration)
+	GetTrustedGerTime(lastProcessTime time.Duration)
+	GetTrustedExitRootsTime(lastProcessTime time.Duration)
+	DepositCounter()
+	ClaimCounter()
+	VerifyBatchCounter()
+	RemoveL2GERCounter()
+	L2GERCounter()
+	L1GERCounter()
+	ReorgCounter()
+	ReorgedBlocksCounter()
+	WrappedTokensCounter()
+}
+
+type Metrics struct {
+	prefix string
+}
+
 // Register the metrics for the synchronizer package.
-func Register(networkID uint32) {
+func Register(networkID uint32) MetricsInterface {
 	registerMutex.Lock()
 	defer registerMutex.Unlock()
 	// Prefix for the metrics of the synchronizer package.
-	Prefix = "synchronizer_networkID_" + fmt.Sprintf("%d", networkID) + "_"
+	prefix := "synchronizer_networkID_" + fmt.Sprintf("%d_", networkID)
 
 	gauges := []prometheus.GaugeOpts{
 		{
-			Name: Prefix + CurrentPendingBridgesToClaimName,
+			Name: prefix + CurrentPendingBridgesToClaimName,
 			Help: "[SYNCHRONIZER] current pending deposits to claim",
 		},
 		{
-			Name: Prefix + LatestBlockSyncedName,
+			Name: prefix + LatestBlockSyncedName,
 			Help: "[SYNCHRONIZER] latest block synced",
 		},
 	}
 	counters := []prometheus.CounterOpts{
 		{
-			Name: Prefix + DepositCounterName,
+			Name: prefix + DepositCounterName,
 			Help: "[SYNCHRONIZER] count processed deposit events",
 		},
 		{
-			Name: Prefix + L1GERCounterName,
+			Name: prefix + L1GERCounterName,
 			Help: "[SYNCHRONIZER] count processed L1 GER events",
 		},
 		{
-			Name: Prefix + L2GERCounterName,
+			Name: prefix + L2GERCounterName,
 			Help: "[SYNCHRONIZER] count processed L2 GER events",
 		},
 		{
-			Name: Prefix + RemoveL2GERCounterName,
+			Name: prefix + RemoveL2GERCounterName,
 			Help: "[SYNCHRONIZER] count processed remove L2 GER events",
 		},
 		{
-			Name: Prefix + VerifyBatchCounterName,
+			Name: prefix + VerifyBatchCounterName,
 			Help: "[SYNCHRONIZER] count processed verify batch events",
 		},
 		{
-			Name: Prefix + ClaimCounterName,
+			Name: prefix + ClaimCounterName,
 			Help: "[SYNCHRONIZER] count processed claim events",
 		},
 		{
-			Name: Prefix + ReorgCounterName,
+			Name: prefix + ReorgCounterName,
 			Help: "[SYNCHRONIZER] count the number of reorgs",
 		},
 		{
-			Name: Prefix + ReorgedBlockCounterName,
+			Name: prefix + ReorgedBlockCounterName,
 			Help: "[SYNCHRONIZER] count the reorged blocks",
 		},
 		{
-			Name: Prefix + WrappedTokensCounterName,
+			Name: prefix + WrappedTokensCounterName,
 			Help: "[SYNCHRONIZER] count the wrapped tokens",
 		},
 	}
 	histograms := []prometheus.HistogramOpts{
 		{
-			Name: Prefix + InitializationTimeName,
+			Name: prefix + InitializationTimeName,
 			Help: "[SYNCHRONIZER] initialization time",
 		},
 		{
-			Name: Prefix + FullTrustedSyncTimeName,
+			Name: prefix + FullTrustedSyncTimeName,
 			Help: "[SYNCHRONIZER] full trusted state synchronization time",
 		},
 		{
-			Name: Prefix + FullL1SyncTimeName,
+			Name: prefix + FullL1SyncTimeName,
 			Help: "[SYNCHRONIZER] full L1 synchronization time",
 		},
 		{
-			Name: Prefix + FullSyncIterationTimeName,
+			Name: prefix + FullSyncIterationTimeName,
 			Help: "[SYNCHRONIZER] full synchronization iteration time",
 		},
 		{
-			Name: Prefix + ReadL1DataTimeName,
+			Name: prefix + ReadL1DataTimeName,
 			Help: "[SYNCHRONIZER] read L1 data time",
 		},
 		{
-			Name: Prefix + ProcessL1DataTimeName,
+			Name: prefix + ProcessL1DataTimeName,
 			Help: "[SYNCHRONIZER] process L1 data time",
 		},
 		{
-			Name: Prefix + GetTrustedGerTimeName,
+			Name: prefix + GetTrustedGerTimeName,
 			Help: "[SYNCHRONIZER] get trusted GER time",
 		},
 		{
-			Name: Prefix + GetTrustedExitRootsTimeName,
+			Name: prefix + GetTrustedExitRootsTimeName,
 			Help: "[SYNCHRONIZER] get trusted ExitRoots time",
 		},
 		{
-			Name: Prefix + DepositAmountName,
+			Name: prefix + DepositAmountName,
 			Help: "[SYNCHRONIZER] deposit amount",
 		},
 		{
-			Name: Prefix + ClaimAmountName,
+			Name: prefix + ClaimAmountName,
 			Help: "[SYNCHRONIZER] claim amount",
 		},
 	}
@@ -181,129 +209,132 @@ func Register(networkID uint32) {
 	metrics.RegisterHistograms(histograms...)
 	metrics.RegisterCounters(counters...)
 	metrics.RegisterGauges(gauges...)
+
+	return &Metrics{
+		prefix: prefix,
+	}
 }
 
 // LatestBlockSynced sets the latest block synced on the gauge.
-func LatestBlockSynced(blockNumber uint64) {
+func (m *Metrics) LatestBlockSynced(blockNumber uint64) {
 	// Be careful, this uint64 to float64 converion can overflow
-	metrics.GaugeSet(Prefix+LatestBlockSyncedName, float64(blockNumber))
+	metrics.GaugeSet(m.prefix+LatestBlockSyncedName, float64(blockNumber))
 }
 
 // IncrementsPendingBridgesToClaim increments the current pending bridges to claim on the gauge.
-func IncrementsPendingBridgesToClaim(destNetwork uint32) {
+func (m *Metrics) IncrementsPendingBridgesToClaim() {
 	// This method modify the metric on the destination network.
 	// It won't do nothing if the dest network is not synced and the metrics in the dest network are not registered.
-	prefixKey := "synchronizer_networkID_" + fmt.Sprintf("%d", destNetwork) + "_"
-	metrics.GaugeInc(prefixKey + CurrentPendingBridgesToClaimName)
+	metrics.GaugeInc(m.prefix + CurrentPendingBridgesToClaimName)
 }
 
 // DecrementsPendingBridgesToClaim decrements the current pending bridges to claim on the gauge.
-func DecrementsPendingBridgesToClaim() {
+func (m *Metrics) DecrementsPendingBridgesToClaim() {
 	// Decrements the current pending bridges to claim on the network that received the claim.
-	metrics.GaugeDec(Prefix + CurrentPendingBridgesToClaimName)
+	metrics.GaugeDec(m.prefix + CurrentPendingBridgesToClaimName)
 }
 
 // DepositAmount observes the value of the deposit amount on the histogram.
-func DepositAmount(amount *big.Int) {
+func (m *Metrics) DepositAmount(amount *big.Int) {
 	a, _ := amount.Float64()
-	metrics.HistogramObserve(Prefix+DepositAmountName, a)
+	metrics.HistogramObserve(m.prefix+DepositAmountName, a)
 }
 
 // ClaimAmount observes the value of the Claim amount on the histogram.
-func ClaimAmount(amount *big.Int) {
+func (m *Metrics) ClaimAmount(amount *big.Int) {
 	a, _ := amount.Float64()
-	metrics.HistogramObserve(Prefix+ClaimAmountName, a)
+	metrics.HistogramObserve(m.prefix+ClaimAmountName, a)
 }
 
 // InitializationTime observes the time initializing the synchronizer on the histogram.
-func InitializationTime(lastProcessTime time.Duration) {
+func (m *Metrics) InitializationTime(lastProcessTime time.Duration) {
 	execTimeInSeconds := float64(lastProcessTime) / float64(time.Second)
-	metrics.HistogramObserve(Prefix+InitializationTimeName, execTimeInSeconds)
+	metrics.HistogramObserve(m.prefix+InitializationTimeName, execTimeInSeconds)
 }
 
 // FullTrustedSyncTime observes the time for synchronize the trusted state on the histogram.
-func FullTrustedSyncTime(lastProcessTime time.Duration) {
+func (m *Metrics) FullTrustedSyncTime(lastProcessTime time.Duration) {
 	execTimeInSeconds := float64(lastProcessTime) / float64(time.Second)
-	metrics.HistogramObserve(Prefix+FullTrustedSyncTimeName, execTimeInSeconds)
+	metrics.HistogramObserve(m.prefix+FullTrustedSyncTimeName, execTimeInSeconds)
 }
 
 // FullL1SyncTime observes the time for synchronize the trusted state on the histogram.
-func FullL1SyncTime(lastProcessTime time.Duration) {
+func (m *Metrics) FullL1SyncTime(lastProcessTime time.Duration) {
 	execTimeInSeconds := float64(lastProcessTime) / float64(time.Second)
-	metrics.HistogramObserve(Prefix+FullL1SyncTimeName, execTimeInSeconds)
+	metrics.HistogramObserve(m.prefix+FullL1SyncTimeName, execTimeInSeconds)
 }
 
 // FullSyncIterationTime observes the time for synchronize the trusted state on the histogram.
-func FullSyncIterationTime(lastProcessTime time.Duration) {
+func (m *Metrics) FullSyncIterationTime(lastProcessTime time.Duration) {
 	execTimeInSeconds := float64(lastProcessTime) / float64(time.Second)
-	metrics.HistogramObserve(Prefix+FullSyncIterationTimeName, execTimeInSeconds)
+	metrics.HistogramObserve(m.prefix+FullSyncIterationTimeName, execTimeInSeconds)
 }
 
 // ReadL1DataTime observes the time for synchronize the trusted state on the histogram.
-func ReadL1DataTime(lastProcessTime time.Duration) {
+func (m *Metrics) ReadL1DataTime(lastProcessTime time.Duration) {
 	execTimeInSeconds := float64(lastProcessTime) / float64(time.Second)
-	metrics.HistogramObserve(Prefix+ReadL1DataTimeName, execTimeInSeconds)
+	metrics.HistogramObserve(m.prefix+ReadL1DataTimeName, execTimeInSeconds)
 }
 
 // ProcessL1DataTime observes the time for synchronize the trusted state on the histogram.
-func ProcessL1DataTime(lastProcessTime time.Duration) {
+func (m *Metrics) ProcessL1DataTime(lastProcessTime time.Duration) {
 	execTimeInSeconds := float64(lastProcessTime) / float64(time.Second)
-	metrics.HistogramObserve(Prefix+ProcessL1DataTimeName, execTimeInSeconds)
+	metrics.HistogramObserve(m.prefix+ProcessL1DataTimeName, execTimeInSeconds)
 }
 
 // GetTrustedGerTime observes the time for synchronize the trusted state on the histogram.
-func GetTrustedGerTime(lastProcessTime time.Duration) {
+func (m *Metrics) GetTrustedGerTime(lastProcessTime time.Duration) {
 	execTimeInSeconds := float64(lastProcessTime) / float64(time.Second)
-	metrics.HistogramObserve(Prefix+GetTrustedGerTimeName, execTimeInSeconds)
+	metrics.HistogramObserve(m.prefix+GetTrustedGerTimeName, execTimeInSeconds)
 }
 
 // GetTrustedExitRootsTime observes the time for synchronize the trusted state on the histogram.
-func GetTrustedExitRootsTime(lastProcessTime time.Duration) {
+func (m *Metrics) GetTrustedExitRootsTime(lastProcessTime time.Duration) {
 	execTimeInSeconds := float64(lastProcessTime) / float64(time.Second)
-	metrics.HistogramObserve(Prefix+GetTrustedExitRootsTimeName, execTimeInSeconds)
+	metrics.HistogramObserve(m.prefix+GetTrustedExitRootsTimeName, execTimeInSeconds)
 }
 
 // DepositCounter increases the counter for the processed deposits
-func DepositCounter() {
-	metrics.CounterInc(Prefix + DepositCounterName)
+func (m *Metrics) DepositCounter() {
+	metrics.CounterInc(m.prefix + DepositCounterName)
 }
 
 // ClaimCounter increases the counter for the processed claims
-func ClaimCounter() {
-	metrics.CounterInc(Prefix + ClaimCounterName)
+func (m *Metrics) ClaimCounter() {
+	metrics.CounterInc(m.prefix + ClaimCounterName)
 }
 
 // VerifyBatchCounter increases the counter for the processed verifyBatches
-func VerifyBatchCounter() {
-	metrics.CounterInc(Prefix + VerifyBatchCounterName)
+func (m *Metrics) VerifyBatchCounter() {
+	metrics.CounterInc(m.prefix + VerifyBatchCounterName)
 }
 
 // RemoveL2GERCounter increases the counter for the processed removeL2GERs
-func RemoveL2GERCounter() {
-	metrics.CounterInc(Prefix + RemoveL2GERCounterName)
+func (m *Metrics) RemoveL2GERCounter() {
+	metrics.CounterInc(m.prefix + RemoveL2GERCounterName)
 }
 
 // L2GERCounter increases the counter for the processed L2GER
-func L2GERCounter() {
-	metrics.CounterInc(Prefix + L2GERCounterName)
+func (m *Metrics) L2GERCounter() {
+	metrics.CounterInc(m.prefix + L2GERCounterName)
 }
 
 // L1GERCounter increases the counter for the processed L1GER
-func L1GERCounter() {
-	metrics.CounterInc(Prefix + L1GERCounterName)
+func (m *Metrics) L1GERCounter() {
+	metrics.CounterInc(m.prefix + L1GERCounterName)
 }
 
 // ReorgCounter increases the counter each reorg
-func ReorgCounter() {
-	metrics.CounterInc(Prefix + ReorgCounterName)
+func (m *Metrics) ReorgCounter() {
+	metrics.CounterInc(m.prefix + ReorgCounterName)
 }
 
 // ReorgedBlockCounter increases the counter for the processed Reorged Block
-func ReorgedBlocksCounter() {
-	metrics.CounterInc(Prefix + ReorgedBlockCounterName)
+func (m *Metrics) ReorgedBlocksCounter() {
+	metrics.CounterInc(m.prefix + ReorgedBlockCounterName)
 }
 
 // WrappedTokensCounter increases the counter for the processed wrappedTokens
-func WrappedTokensCounter() {
-	metrics.CounterInc(Prefix + WrappedTokensCounterName)
+func (m *Metrics) WrappedTokensCounter() {
+	metrics.CounterInc(m.prefix + WrappedTokensCounterName)
 }

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -116,6 +116,7 @@ func (s *ClientSynchronizer) Sync() error {
 	// Get the latest synced block. If there is no block on db, use genesis block
 	log.Infof("NetworkID: %d, Synchronization started", s.networkID)
 	lastBlockSynced, err := s.storage.GetLastBlock(s.ctx, s.networkID, nil)
+	s.metrics.LatestBlockSynced(lastBlockSynced.BlockNumber)
 	if err != nil {
 		if err == gerror.ErrStorageNotFound {
 			log.Warnf("networkID: %d, error getting the latest ethereum block. No data stored. Setting genesis block. Error: %v", s.networkID, err)

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -323,9 +323,10 @@ func (s *ClientSynchronizer) syncBlocks(lastBlockSynced etherman.Block) (*etherm
 		blocks, order, err := s.etherMan.GetRollupInfoByBlockRange(s.ctx, fromBlock, &toBlock)
 		s.metrics.ReadL1DataTime(time.Since(start))
 		if err != nil {
+			log.Errorf("networkID: %d, error getting rollup info from block %d to block %d. Error: %v", s.networkID, fromBlock, toBlock, err)
 			return &lastBlockSynced, err
 		}
-
+		s.metrics.LatestBlockRollupInfo(toBlock)
 		if fromBlock == s.genBlockNumber && !s.forceSyncChunk {
 			if len(blocks) == 0 || (len(blocks) != 0 && blocks[0].BlockNumber != s.genBlockNumber) {
 				log.Debugf("NetworkID: %d. adding genesis empty block", s.networkID)

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -40,6 +40,7 @@ type ClientSynchronizer struct {
 	sovereignChain    bool
 	forceSyncChunk    bool
 	waitDuration      time.Duration
+	metrics           metrics.MetricsInterface
 }
 
 // NewSynchronizer creates and initializes an instance of Synchronizer
@@ -58,7 +59,6 @@ func NewSynchronizer(
 	sovereignChain bool) (Synchronizer, error) {
 	ctx, cancel := context.WithCancel(parentCtx)
 	networkID := ethMan.GetNetworkID()
-	metrics.Register(networkID)
 	ger, err := storage.(storageInterface).GetLatestL1SyncedExitRoot(ctx, nil)
 	if err != nil {
 		if err == gerror.ErrStorageNotFound {
@@ -86,6 +86,7 @@ func NewSynchronizer(
 			allNetworkIDs:    allNetworkIDs,
 			forceSyncChunk:   false,
 			waitDuration:     time.Duration(0),
+			metrics:          metrics.Register(networkID),
 		}, nil
 	}
 	return &ClientSynchronizer{
@@ -103,6 +104,7 @@ func NewSynchronizer(
 		sovereignChain:    sovereignChain,
 		forceSyncChunk:    cfg.ForceL2SyncChunk,
 		waitDuration:      time.Duration(0),
+		metrics:           metrics.Register(networkID),
 	}, nil
 }
 
@@ -128,7 +130,7 @@ func (s *ClientSynchronizer) Sync() error {
 			return err
 		}
 	}
-	metrics.InitializationTime(time.Since(startInitialization))
+	s.metrics.InitializationTime(time.Since(startInitialization))
 	log.Debugf("NetworkID: %d, initial lastBlockSynced: %+v", s.networkID, lastBlockSynced)
 	for {
 		select {
@@ -140,7 +142,7 @@ func (s *ClientSynchronizer) Sync() error {
 			log.Debugf("NetworkID: %d, syncing...", s.networkID)
 			//Sync L1Blocks
 			lastBlockSynced, err = s.syncBlocks(*lastBlockSynced)
-			metrics.FullL1SyncTime(time.Since(start))
+			s.metrics.FullL1SyncTime(time.Since(start))
 			if err != nil {
 				log.Warnf("networkID: %d, error syncing blocks: %v", s.networkID, err)
 				lastBlockSynced, err = s.storage.GetLastBlock(s.ctx, s.networkID, nil)
@@ -193,12 +195,12 @@ func (s *ClientSynchronizer) Sync() error {
 				log.Infof("networkID: %d, Virtual state is synced, getting trusted state", s.networkID)
 				startTrusted := time.Now()
 				err = s.syncTrustedState()
-				metrics.FullTrustedSyncTime(time.Since(startTrusted))
+				s.metrics.FullTrustedSyncTime(time.Since(startTrusted))
 				if err != nil {
 					log.Errorf("networkID: %d, error getting current trusted state", s.networkID)
 				}
 			}
-			metrics.FullSyncIterationTime(time.Since(start))
+			s.metrics.FullSyncIterationTime(time.Since(start))
 		}
 	}
 }
@@ -212,7 +214,7 @@ func (s *ClientSynchronizer) Stop() {
 func (s *ClientSynchronizer) syncTrustedState() error {
 	start := time.Now()
 	lastGER, err := s.zkEVMClient.GetLatestGlobalExitRoot(s.ctx)
-	metrics.GetTrustedGerTime(time.Since(start))
+	s.metrics.GetTrustedGerTime(time.Since(start))
 	if err != nil {
 		log.Warnf("networkID: %d, failed to get latest ger from trusted state. Error: %v", s.networkID, err)
 		return err
@@ -223,7 +225,7 @@ func (s *ClientSynchronizer) syncTrustedState() error {
 	}
 	start = time.Now()
 	exitRoots, err := s.zkEVMClient.ExitRootsByGER(s.ctx, lastGER)
-	metrics.GetTrustedExitRootsTime(time.Since(start))
+	s.metrics.GetTrustedExitRootsTime(time.Since(start))
 	if err != nil {
 		log.Warnf("networkID: %d, failed to get exitRoots from trusted state. Error: %v", s.networkID, err)
 		return err
@@ -318,7 +320,7 @@ func (s *ClientSynchronizer) syncBlocks(lastBlockSynced etherman.Block) (*etherm
 		// The value pos (position) tells what is the array index where this value is.
 		start := time.Now()
 		blocks, order, err := s.etherMan.GetRollupInfoByBlockRange(s.ctx, fromBlock, &toBlock)
-		metrics.ReadL1DataTime(time.Since(start))
+		s.metrics.ReadL1DataTime(time.Since(start))
 		if err != nil {
 			return &lastBlockSynced, err
 		}
@@ -384,7 +386,7 @@ func (s *ClientSynchronizer) syncBlocks(lastBlockSynced etherman.Block) (*etherm
 
 		start = time.Now()
 		err = s.processBlockRange(blocks, order)
-		metrics.ProcessL1DataTime(time.Since(start))
+		s.metrics.ProcessL1DataTime(time.Since(start))
 		if err != nil {
 			return &lastBlockSynced, err
 		}
@@ -474,9 +476,9 @@ func (s *ClientSynchronizer) processBlockRange(blocks []etherman.Block, order ma
 					return err
 				}
 				if isNewL1Ger {
-					metrics.L1GERCounter()
+					s.metrics.L1GERCounter()
 				} else if isNewL2Ger {
-					metrics.L2GERCounter()
+					s.metrics.L2GERCounter()
 				}
 			case etherman.RemoveL2GEROrder:
 				if len(blocks[i].RemoveL2GER) < element.Pos+1 {
@@ -486,7 +488,7 @@ func (s *ClientSynchronizer) processBlockRange(blocks []etherman.Block, order ma
 				if err != nil {
 					return err
 				}
-				metrics.RemoveL2GERCounter()
+				s.metrics.RemoveL2GERCounter()
 			case etherman.DepositsOrder:
 				if len(blocks[i].Deposits) < element.Pos+1 {
 					return fmt.Errorf("deposits event error: invalid data received from the RPC. Probably, messy events were received from the RPC. Block: %+v. Order: %+v", blocks[i], order[blocks[i].BlockHash])
@@ -495,7 +497,7 @@ func (s *ClientSynchronizer) processBlockRange(blocks []etherman.Block, order ma
 				if err != nil {
 					return err
 				}
-				metrics.DepositCounter()
+				s.metrics.DepositCounter()
 			case etherman.ClaimsOrder:
 				if len(blocks[i].Claims) < element.Pos+1 {
 					return fmt.Errorf("claims event error: invalid data received from the RPC. Probably, messy events were received from the RPC. Block: %+v. Order: %+v", blocks[i], order[blocks[i].BlockHash])
@@ -504,7 +506,7 @@ func (s *ClientSynchronizer) processBlockRange(blocks []etherman.Block, order ma
 				if err != nil {
 					return err
 				}
-				metrics.ClaimCounter()
+				s.metrics.ClaimCounter()
 			case etherman.TokensOrder:
 				if len(blocks[i].Tokens) < element.Pos+1 {
 					return fmt.Errorf("tokens event error: invalid data received from the RPC. Probably, messy events were received from the RPC. Block: %+v. Order: %+v", blocks[i], order[blocks[i].BlockHash])
@@ -521,7 +523,7 @@ func (s *ClientSynchronizer) processBlockRange(blocks []etherman.Block, order ma
 				if err != nil {
 					return err
 				}
-				metrics.VerifyBatchCounter()
+				s.metrics.VerifyBatchCounter()
 			}
 		}
 		err = s.storage.Commit(s.ctx, dbTx)
@@ -647,7 +649,7 @@ func (s *ClientSynchronizer) checkReorg(latestStoredBlock etherman.Block, synced
 				return nil, err
 			}
 			reorgedBlock = lb
-			metrics.ReorgedBlocksCounter()
+			s.metrics.ReorgedBlocksCounter()
 		} else {
 			log.Debugf("networkID: %d, checkReorg: Block %d hashOk %t", s.networkID, reorgedBlock.BlockNumber, block.BlockHash == reorgedBlock.BlockHash)
 			break
@@ -658,7 +660,7 @@ func (s *ClientSynchronizer) checkReorg(latestStoredBlock etherman.Block, synced
 	if latestStoredEthBlock.BlockHash != reorgedBlock.BlockHash {
 		latestStoredBlock = reorgedBlock
 		log.Info("NetworkID: ", s.networkID, ", reorg detected in block: ", latestStoredEthBlock.BlockNumber, " last block OK: ", latestStoredBlock.BlockNumber)
-		metrics.ReorgCounter()
+		s.metrics.ReorgCounter()
 		return &latestStoredBlock, nil
 	}
 	log.Debugf("NetworkID: %d, no reorg detected in block: %d. BlockHash: %s", s.networkID, latestStoredEthBlock.BlockNumber, latestStoredEthBlock.BlockHash.String())
@@ -770,7 +772,7 @@ func (s *ClientSynchronizer) processDeposit(deposit etherman.Deposit, blockID ui
 		log.Errorf("networkID: %d, failed to store new deposit in the bridge tree, BlockNumber: %d, Deposit: %+v err: %v", s.networkID, deposit.BlockNumber, deposit, err)
 		return s.rollback(deposit.BlockNumber, err, dbTx)
 	}
-	metrics.DepositAmount(deposit.Amount)
+	s.metrics.DepositAmount(deposit.Amount)
 	return nil
 }
 
@@ -782,7 +784,7 @@ func (s *ClientSynchronizer) processClaim(claim etherman.Claim, blockID uint64, 
 		log.Errorf("networkID: %d, error storing new Claim in Block:  %d, Claim: %+v, err: %v", s.networkID, claim.BlockNumber, claim, err)
 		return s.rollback(claim.BlockNumber, err, dbTx)
 	}
-	metrics.ClaimAmount(claim.Amount)
+	s.metrics.ClaimAmount(claim.Amount)
 	return nil
 }
 
@@ -794,7 +796,7 @@ func (s *ClientSynchronizer) processTokenWrapped(tokenWrapped etherman.TokenWrap
 		log.Errorf("networkID: %d, error storing new L1 TokenWrapped in Block:  %d, TokenWrapped: %+v, err: %v", s.networkID, tokenWrapped.BlockNumber, tokenWrapped, err)
 		return s.rollback(tokenWrapped.BlockNumber, err, dbTx)
 	}
-	metrics.WrappedTokensCounter()
+	s.metrics.WrappedTokensCounter()
 	return nil
 }
 


### PR DESCRIPTION
Closes #831 #830 #826

### What does this PR do?
[fix(metrics): refactor metrics handling in synchronizer](https://github.com/0xPolygonHermez/zkevm-bridge-service/commit/75f446b6484cc52f164ea93fc52d52d71115cd41) 

fixes https://github.com/0xPolygonHermez/zkevm-bridge-service/issues/830

- Introduced MetricsInterface to encapsulate metrics operations.
- Updated ClientSynchronizer to utilize the new metrics structure for better organization and clarity.
- Enhanced metric tracking for various synchronization processes to improve observability and debugging.

[fix(metrics): track latest synced block in synchronization process](https://github.com/0xPolygonHermez/zkevm-bridge-service/commit/9de1ebf655d07810e86779505af9f722f1b4ac81) 

fixes https://github.com/0xPolygonHermez/zkevm-bridge-service/issues/826

Added a call to metrics.LatestBlockSynced to log the latest block number synced during the synchronization process. This enhancement improves monitoring and debugging capabilities by providing visibility into the synchronization state.

[feat(metrics): add latest block rollup info metric](https://github.com/0xPolygonHermez/zkevm-bridge-service/commit/975d2a8068faef52446c323598a73742e5caeb0e) 

implements https://github.com/0xPolygonHermez/zkevm-bridge-service/issues/831

This change introduces a new metric for tracking the latest block rollup info in the synchronizer package. It enhances the observability of the synchronization process by allowing users to monitor rollup information alongside the latest synced block.


### Reviewers

Main reviewers:
- @John
- @Doe
- @ARR552


Codeowner reviewers:
- @Alice
- @Bob
