### PR TITLE
Fix ERC20 L1->L2 bridge test inconsistent failure

### DIFF
--- a/test/e2e/bridge_network_erc20_test.go
+++ b/test/e2e/bridge_network_erc20_test.go
@@ -38,19 +38,11 @@ func TestERC20TransferL1toL2(t *testing.T) {
 
 	// Do Asset L1 -> L2
 	amount := big.NewInt(143210000000001234) // 0.14321 ETH
-	log.Infof("ERC20 [L1->L2] assetERC20L2ToL1")
+	log.Infof("ERC20 [L1->L2] assetERC20L1ToL2")
 	txAssetHash := assetERC20L1ToL2(ctx, testData, t, tokenAddr, amount)
-	log.Infof("ERC20 [L1->L2] assetERC20L2ToL1 txAssetHash: %s ", txAssetHash.String())
+	log.Infof("ERC20 [L1->L2] assetERC20L1ToL2 txAssetHash: %s ", txAssetHash.String())
 	log.Infof("ERC20 [L1->L2] waitToAutoClaim")
-	//waitToAutoClaim(t, ctx, testData, txAssetHash, maxTimeToClaimReady)
-	deposit, err := waitDepositToBeReadyToClaim(ctx, testData, txAssetHash, maxTimeToClaimReady, testData.auth[operations.L1].From.String())
-	require.NoError(t, err)
-	err = waitToAutoClaimTx(t, ctx, testData, deposit, 60*time.Second)
-	if err != nil {
-		log.Errorf("ERC20 [L1->L2] Doing manual claim")
-		err = manualClaimDepositL2(ctx, testData, deposit)
-		require.NoError(t, err)
-	}
+	waitToAutoClaim2(t, ctx, testData, txAssetHash, maxTimeToClaimReady)
 }
 
 func TestERC20TransferL2toL1(t *testing.T) {

--- a/test/e2e/bridge_network_shared.go
+++ b/test/e2e/bridge_network_shared.go
@@ -43,7 +43,7 @@ const (
 	maxTimeToAutoClaim = 60 * time.Minute
 	// Tipically the time to claim a deposit is 1 hours (L2 -> L1)
 	maxTimeToClaimReady   = 120 * time.Minute
-	timeBetweenCheckClaim = 60 * time.Second
+	timeBetweenCheckClaim = 10 * time.Second
 	mtHeight              = 32
 )
 
@@ -406,6 +406,7 @@ func waitToAutoClaimTx(t *testing.T, ctx context.Context, testData *bridge2e2Tes
 		// The claim from L1 -> L2 is done by the bridge service to L2
 		receipt, err := waitTxToBeMinedByTxHash(ctx, testData.L2Client, claimTxHash, 60*time.Second)
 		if err != nil {
+			log.Errorf("Error waiting for claim tx to be mined: %v", err)
 			return err
 		}
 		log.Debug("Receipt: ", receipt, " Elapsed time: ", time.Since(startTime))


### PR DESCRIPTION
Fixes inconsistent ERC20 bridge test L1->L2

Autoclaim method was not using deadline timeout, failed on the first timeout.
Not sure while manual claim failed sometimes too, might be caused by already claiming using autoclaim which could cause revert on subsequent manual claim.
Decreased timeout between checks to claim - 1 minute seems to match some remote timeout which was not enough to discover claims. In my testing I saw autoclaims normally happen after 1 minute. So now the autoclaims succeeed during interval 1m - 1m10s.