### PR TITLE
fix max type for postgresql bigInt

### DIFF
--- a/db/pgstorage/pgstorage.go
+++ b/db/pgstorage/pgstorage.go
@@ -847,7 +847,7 @@ func (p *PostgresStorage) AddRemoveL2GER(ctx context.Context, globalExitRoot eth
 	CurrentDepositID, _, err := p.GetDepositCountByGER(ctx, globalExitRoot.GlobalExitRoot, globalExitRoot.NetworkID, false, dbTx)
 	if errors.Is(err, gerror.ErrStorageNotFound) {
 		log.Warnf("No deposit found for this GER: %s in L1, NetworkID: %d", globalExitRoot.GlobalExitRoot.String(), globalExitRoot.NetworkID)
-		CurrentDepositID = math.MaxUint64
+		CurrentDepositID = math.MaxInt64
 	} else if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do?

this pr fixes this issue:
```
{"level":"error","ts":1766064220.4161685,"caller":"synchronizer/synchronizer.go:877","msg":"networkID: 12, error storing removeL2Ger in Block:  85613, GER: {BlockID:18384 BlockNumber:85613 ExitRoots:[] GlobalExitRoot:0x7d8d6ed6aaf2ee0a8a1c7d1eacc8b8d15c512d4d9f209136bd426389c416b266 NetworkID:12 ID:0}, err: 18446744073709551615 is greater than maximum value for Int8%!(EXTRA string=\n/src/log/log.go:142 github.com/0xPolygon/zkevm-bridge-service/log.appendStackTraceMaybeArgs()\n/src/log/log.go:251 github.com/0xPolygon/zkevm-bridge-service/log.Errorf()\n/src/synchronizer/synchronizer.go:877 github.com/0xPolygon/zkevm-bridge-service/synchronizer.(*ClientSynchronizer).processRemoveL2GlobalExitRoot()\n/src/synchronizer/synchronizer.go:552 github.com/0xPolygon/zkevm-bridge-service/synchronizer.(*ClientSynchronizer).processBlockRange()\n/src/synchronizer/synchronizer.go:424 github.com/0xPolygon/zkevm-bridge-service/synchronizer.(*ClientSynchronizer).syncBlocks()\n/src/synchronizer/synchronizer.go:167 github.com/0xPolygon/zkevm-bridge-service/synchronizer.(*ClientSynchronizer).Sync()\n/src/cmd/run.go:274 main.runSynchronizer()\n)","pid":1,"version":"v0.6.3-RC4","stacktrace":"github.com/0xPolygon/zkevm-bridge-service/synchronizer.(*ClientSynchronizer).processRemoveL2GlobalExitRoot\n\t/src/synchronizer/synchronizer.go:877\ngithub.com/0xPolygon/zkevm-bridge-service/synchronizer.(*ClientSynchronizer).processBlockRange\n\t/src/synchronizer/synchronizer.go:552\ngithub.com/0xPolygon/zkevm-bridge-service/synchronizer.(*ClientSynchronizer).syncBlocks\n\t/src/synchronizer/synchronizer.go:424\ngithub.com/0xPolygon/zkevm-bridge-service/synchronizer.(*ClientSynchronizer).Sync\n\t/src/synchronizer/synchronizer.go:167\nmain.runSynchronizer\n\t/src/cmd/run.go:274"}
{"level":"warn","ts":1766064220.459715,"caller":"synchronizer/synchronizer.go:170","msg":"networkID: 12, error syncing blocks: 18446744073709551615 is greater than maximum value for Int8","pid":1,"version":"v0.6.3-RC4"}
```