### PR TITLE
Fix reorg backward let

### DIFF
--- a/bridgectrl/merkletree_test.go
+++ b/bridgectrl/merkletree_test.go
@@ -169,7 +169,7 @@ func TestMTGetProof(t *testing.T) {
 					BlockNumber: uint64(li + 1), // nolint:gosec
 					BlockHash:   common.HexToHash("0x29e885edaf8e4b51e1d2e05f9da28161d2fb4f6b1d53827d9b80a23cf2d7d9fc"),
 				}
-				blockID, err := testStore.AddBlock(context.TODO(), block, nil)
+				blockID, err := testStore.AddBlock(ctx, block, nil)
 				require.NoError(t, err)
 				deposit := &etherman.Deposit{
 					OriginalNetwork:    leaf.OriginalNetwork,

--- a/db/pgstorage/migrations/0022.sql
+++ b/db/pgstorage/migrations/0022.sql
@@ -1,0 +1,24 @@
+-- +migrate Up
+
+CREATE TABLE IF NOT EXISTS sync.deposit_backup
+(
+    leaf_type   INTEGER,
+    network_id  BIGINT,
+    orig_net    BIGINT,
+    orig_addr   BYTEA NOT NULL,
+    amount      VARCHAR,
+    dest_net    BIGINT NOT NULL,
+    dest_addr   BYTEA NOT NULL,
+    block_id    BIGINT REFERENCES sync.block (id) ON DELETE CASCADE,
+    deposit_cnt BIGINT,
+    tx_hash     BYTEA NOT NULL,
+    metadata    BYTEA NOT NULL,
+    id          BIGSERIAL,
+    ready_for_claim BOOLEAN DEFAULT false NOT NULL,
+    backward_let_id BIGINT NOT NULL,
+    PRIMARY KEY (id)
+);
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS sync.deposit_backup;

--- a/db/pgstorage/migrations/0022.sql
+++ b/db/pgstorage/migrations/0022.sql
@@ -19,6 +19,11 @@ CREATE TABLE IF NOT EXISTS sync.deposit_backup
     PRIMARY KEY (id)
 );
 
+-- Add index on backward_let_id for faster orphan lookups and JOIN operations
+CREATE INDEX IF NOT EXISTS idx_deposit_backup_backward_let_id
+ON sync.deposit_backup(backward_let_id);
+
 -- +migrate Down
 
+DROP INDEX IF EXISTS sync.idx_deposit_backup_backward_let_id;
 DROP TABLE IF EXISTS sync.deposit_backup;

--- a/db/pgstorage/migrations/0022_test.go
+++ b/db/pgstorage/migrations/0022_test.go
@@ -1,0 +1,58 @@
+package migrations_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type migrationTest0022 struct{}
+
+func (m migrationTest0022) InsertData(db *sql.DB) error {
+	block := "INSERT INTO sync.block (id, block_num, block_hash, network_id) VALUES(1, 1, decode('C9B5033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C07','hex'), 0);"
+	if _, err := db.Exec(block); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m migrationTest0022) RunAssertsAfterMigrationUp(t *testing.T, db *sql.DB) {
+	insertDepositBackup := `INSERT INTO sync.deposit_backup(leaf_type, network_id, orig_net, orig_addr, amount, dest_net, dest_addr, block_id, deposit_cnt, tx_hash, metadata, ready_for_claim, backward_let_id)
+		VALUES(0, 1, 0, decode('A9B5033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C08','hex'), '1000000000000000000', 1, decode('B9B5033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C09','hex'), 1, 5, decode('C9B5033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C10','hex'), decode('D9B5033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C11','hex'), true, 1);`
+	_, err := db.Exec(insertDepositBackup)
+	assert.NoError(t, err)
+
+	var count uint32
+	selectCount := "SELECT count(*) FROM sync.deposit_backup"
+	err = db.QueryRow(selectCount).Scan(&count)
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(1), count)
+
+	// Verify the data was inserted correctly
+	var leafType, networkID, origNet, destNet, depositCnt, backwardLetID int64
+	var amount string
+	var readyForClaim bool
+	selectData := "SELECT leaf_type, network_id, orig_net, amount, dest_net, deposit_cnt, ready_for_claim, backward_let_id FROM sync.deposit_backup WHERE id = 1"
+	err = db.QueryRow(selectData).Scan(&leafType, &networkID, &origNet, &amount, &destNet, &depositCnt, &readyForClaim, &backwardLetID)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), leafType)
+	assert.Equal(t, int64(1), networkID)
+	assert.Equal(t, int64(0), origNet)
+	assert.Equal(t, "1000000000000000000", amount)
+	assert.Equal(t, int64(1), destNet)
+	assert.Equal(t, int64(5), depositCnt)
+	assert.Equal(t, true, readyForClaim)
+	assert.Equal(t, int64(1), backwardLetID)
+}
+
+func (m migrationTest0022) RunAssertsAfterMigrationDown(t *testing.T, db *sql.DB) {
+	var count uint32
+	selectCount := "SELECT count(*) FROM sync.deposit_backup"
+	err := db.QueryRow(selectCount).Scan(&count)
+	assert.Error(t, err)
+}
+
+func TestMigration0022(t *testing.T) {
+	runMigrationTest(t, 22, migrationTest0022{})
+}

--- a/db/pgstorage/migrations/0022_test.go
+++ b/db/pgstorage/migrations/0022_test.go
@@ -44,13 +44,38 @@ func (m migrationTest0022) RunAssertsAfterMigrationUp(t *testing.T, db *sql.DB) 
 	assert.Equal(t, int64(5), depositCnt)
 	assert.Equal(t, true, readyForClaim)
 	assert.Equal(t, int64(1), backwardLetID)
+
+	// Verify the index was created
+	var indexExists bool
+	checkIndex := `SELECT EXISTS (
+		SELECT 1 FROM pg_indexes
+		WHERE schemaname = 'sync'
+		AND tablename = 'deposit_backup'
+		AND indexname = 'idx_deposit_backup_backward_let_id'
+	)`
+	err = db.QueryRow(checkIndex).Scan(&indexExists)
+	assert.NoError(t, err)
+	assert.True(t, indexExists, "Index idx_deposit_backup_backward_let_id should exist")
 }
 
 func (m migrationTest0022) RunAssertsAfterMigrationDown(t *testing.T, db *sql.DB) {
+	// Verify the table was dropped
 	var count uint32
 	selectCount := "SELECT count(*) FROM sync.deposit_backup"
 	err := db.QueryRow(selectCount).Scan(&count)
 	assert.Error(t, err)
+
+	// Verify the index was also removed
+	var indexExists bool
+	checkIndex := `SELECT EXISTS (
+		SELECT 1 FROM pg_indexes
+		WHERE schemaname = 'sync'
+		AND tablename = 'deposit_backup'
+		AND indexname = 'idx_deposit_backup_backward_let_id'
+	)`
+	err = db.QueryRow(checkIndex).Scan(&indexExists)
+	assert.NoError(t, err)
+	assert.False(t, indexExists, "Index idx_deposit_backup_backward_let_id should not exist after migration down")
 }
 
 func TestMigration0022(t *testing.T) {

--- a/db/pgstorage/pgstorage.go
+++ b/db/pgstorage/pgstorage.go
@@ -1000,6 +1000,36 @@ func (p *PostgresStorage) GetLastComputedRoot(ctx context.Context, networkID uin
 	return root, nil
 }
 
+// GetAndDeleteOrphanDepositBackups finds and deletes deposit_backup records whose backward_let_id
+// does not exist in the backward_let table, returning the deleted deposits.
+// This uses a single optimized DELETE query with RETURNING clause and LEFT JOIN for better performance.
+func (p *PostgresStorage) GetAndDeleteOrphanDepositBackups(ctx context.Context, dbTx interface{}) ([]*etherman.Deposit, error) {
+	// Single query that deletes orphan deposits and returns them in one operation
+	// Using LEFT JOIN with NULL check is often faster than NOT EXISTS for this use case
+	const deleteAndReturnOrphanDepositsSQL = `
+		DELETE FROM sync.deposit_backup AS db
+		USING (
+			SELECT db2.id
+			FROM sync.deposit_backup AS db2
+			LEFT JOIN sync.backward_let AS bl ON bl.id = db2.backward_let_id
+			WHERE bl.id IS NULL
+		) AS orphans
+		WHERE db.id = orphans.id
+		RETURNING db.id, db.leaf_type, db.orig_net, db.orig_addr, db.amount, db.dest_net,
+		          db.dest_addr, db.deposit_cnt, db.block_id, db.network_id, db.tx_hash,
+		          db.metadata, db.ready_for_claim`
+
+	e := p.getExecQuerier(dbTx)
+	rows, err := e.Query(ctx, deleteAndReturnOrphanDepositsSQL)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	// Parse and return the deleted deposits
+	return parseDeposits(rows, false)
+}
+
 // UpdateDepositsStatusForTesting updates the ready_for_claim status of all deposits for testing.
 func (p *PostgresStorage) UpdateDepositsStatusForTesting(ctx context.Context, dbTx interface{}) error {
 	const updateDepositsStatusSQL = "UPDATE sync.deposit SET ready_for_claim = true;"

--- a/db/pgstorage/pgstorage.go
+++ b/db/pgstorage/pgstorage.go
@@ -922,22 +922,39 @@ func (p *PostgresStorage) GetSyncStatus(ctx context.Context, dbTx interface{}) (
 }
 
 // ResetDeposits resets the state to a depositCount.
-func (p *PostgresStorage) ResetDeposits(ctx context.Context, depositCount uint32, networkID uint32, dbTx interface{}) error {
+func (p *PostgresStorage) ResetDeposits(ctx context.Context, depositCount uint32, networkID uint32, backwardLETID uint64, dbTx interface{}) error {
 	if networkID == 0 {
 		return errors.New("cannot reset L1 deposits")
 	}
-	const resetSQL = "DELETE FROM sync.deposit WHERE deposit_cnt >= $1 AND network_id = $2"
+	// Store the deposits in other table and remove from deposit table
+	const resetSQL = "DELETE FROM sync.deposit WHERE deposit_cnt >= $1 AND network_id = $2 RETURNING id, leaf_type, orig_net, orig_addr, amount, dest_net, dest_addr, deposit_cnt, block_id, network_id, tx_hash, metadata, ready_for_claim"
 	e := p.getExecQuerier(dbTx)
 	_, err := e.Exec(ctx, resetSQL, depositCount, networkID)
-	return err
+	rows, err := e.Query(ctx, resetSQL, depositCount, networkID)
+    if err != nil {
+        return err
+    }
+    defer rows.Close()
+	deposits, err := parseDeposits(rows, false)
+	if err != nil {
+		return err
+	}
+	const addDepositSQL = "INSERT INTO sync.deposit_backup (leaf_type, network_id, orig_net, orig_addr, amount, dest_net, dest_addr, block_id, deposit_cnt, tx_hash, metadata, ready_for_claim, backward_let_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)"
+	for _, deposit := range deposits {
+		_, err = e.Exec(ctx, addDepositSQL, deposit.LeafType, deposit.NetworkID, deposit.OriginalNetwork, deposit.OriginalAddress, deposit.Amount.String(), deposit.DestinationNetwork, deposit.DestinationAddress, deposit.BlockID, deposit.DepositCount, deposit.TxHash, deposit.Metadata, deposit.ReadyForClaim, backwardLETID)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // AddBackwardLET adds a new BackwardLET event to the db.
-func (p *PostgresStorage) AddBackwardLET(ctx context.Context, backwardLET *etherman.BackwardLET, dbTx interface{}) error {
-	const addExitRootSQL = "INSERT INTO sync.backward_let(block_id, previous_deposit_cnt, previous_root, new_deposit_cnt, new_root) VALUES ($1, $2, $3, $4, $5)"
-	e := p.getExecQuerier(dbTx)
-	_, err := e.Exec(ctx, addExitRootSQL, backwardLET.BlockID, backwardLET.PreviousDepositCount, backwardLET.PreviousRoot, backwardLET.NewDepositCount, backwardLET.NewRoot)
-	return err
+func (p *PostgresStorage) AddBackwardLET(ctx context.Context, backwardLET *etherman.BackwardLET, dbTx interface{}) (uint64, error) {
+	const addExitRootSQL = "INSERT INTO sync.backward_let(block_id, previous_deposit_cnt, previous_root, new_deposit_cnt, new_root) VALUES ($1, $2, $3, $4, $5) RETURNING id"
+	var id uint64
+	err := p.getExecQuerier(dbTx).QueryRow(ctx, addExitRootSQL, backwardLET.BlockID, backwardLET.PreviousDepositCount, backwardLET.PreviousRoot, backwardLET.NewDepositCount, backwardLET.NewRoot).Scan(&id)
+	return id, err
 }
 
 // AddForwardLET adds a new ForwardLET event to the db.

--- a/db/pgstorage/pgstorage.go
+++ b/db/pgstorage/pgstorage.go
@@ -927,9 +927,17 @@ func (p *PostgresStorage) ResetDeposits(ctx context.Context, depositCount uint32
 		return errors.New("cannot reset L1 deposits")
 	}
 	// Store the deposits in other table and remove from deposit table
-	const resetSQL = "DELETE FROM sync.deposit WHERE deposit_cnt >= $1 AND network_id = $2 RETURNING id, leaf_type, orig_net, orig_addr, amount, dest_net, dest_addr, deposit_cnt, block_id, network_id, tx_hash, metadata, ready_for_claim"
+	// Using CTE to ensure deposits are returned in ascending order by deposit_cnt
+	const resetSQL = `
+		WITH deleted_deposits AS (
+			DELETE FROM sync.deposit
+			WHERE deposit_cnt >= $1 AND network_id = $2
+			RETURNING id, leaf_type, orig_net, orig_addr, amount, dest_net, dest_addr, deposit_cnt, block_id, network_id, tx_hash, metadata, ready_for_claim
+		)
+		SELECT id, leaf_type, orig_net, orig_addr, amount, dest_net, dest_addr, deposit_cnt, block_id, network_id, tx_hash, metadata, ready_for_claim
+		FROM deleted_deposits
+		ORDER BY deposit_cnt ASC`
 	e := p.getExecQuerier(dbTx)
-	_, err := e.Exec(ctx, resetSQL, depositCount, networkID)
 	rows, err := e.Query(ctx, resetSQL, depositCount, networkID)
     if err != nil {
         return err
@@ -1013,6 +1021,7 @@ func (p *PostgresStorage) GetAndDeleteOrphanDepositBackups(ctx context.Context, 
 			FROM sync.deposit_backup AS db2
 			LEFT JOIN sync.backward_let AS bl ON bl.id = db2.backward_let_id
 			WHERE bl.id IS NULL
+			ORDER BY db2.deposit_cnt ASC
 		) AS orphans
 		WHERE db.id = orphans.id
 		RETURNING db.id, db.leaf_type, db.orig_net, db.orig_addr, db.amount, db.dest_net,

--- a/db/pgstorage/pgstorage_test.go
+++ b/db/pgstorage/pgstorage_test.go
@@ -326,6 +326,27 @@ func TestResetDeposits(t *testing.T) {
 	d, err = store.GetNumberDeposits(ctx, 1, 1, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint32(1), d)
+
+	// Verify that deposits were stored in order in deposit_backup table
+	var depositCounts []uint32
+	rows, err := store.Query(ctx, "SELECT deposit_cnt FROM sync.deposit_backup WHERE backward_let_id = 1 ORDER BY id ASC")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	for rows.Next() {
+		var depositCnt uint32
+		err = rows.Scan(&depositCnt)
+		require.NoError(t, err)
+		depositCounts = append(depositCounts, depositCnt)
+	}
+	require.NoError(t, rows.Err())
+
+	// Check that we have 2 deposits (deposit_cnt 1 and 2)
+	require.Len(t, depositCounts, 2)
+
+	// Verify they are in ascending order
+	assert.Equal(t, uint32(1), depositCounts[0], "First deposit should have deposit_cnt = 1")
+	assert.Equal(t, uint32(2), depositCounts[1], "Second deposit should have deposit_cnt = 2")
 }
 
 func TestAddBackwardLET(t *testing.T) {

--- a/db/pgstorage/pgstorage_test.go
+++ b/db/pgstorage/pgstorage_test.go
@@ -690,7 +690,7 @@ func TestGetAndDeleteOrphanDepositBackups(t *testing.T) {
 			expectedAmounts[amountStr] = true
 		}
 		assert.Equal(t, uint32(1), dep.NetworkID, "NetworkID should be 1")
-		assert.Equal(t, uint32(i)+2, dep.DepositCount, "BlockID should be different")
+		assert.Equal(t, uint32(i)+2, dep.DepositCount, "BlockID should be different") // nolint:gosec
 		assert.Equal(t, uint32(0), dep.DestinationNetwork, "DestinationNetwork should be 0")
 	}
 

--- a/db/pgstorage/pgstorage_test.go
+++ b/db/pgstorage/pgstorage_test.go
@@ -316,12 +316,12 @@ func TestResetDeposits(t *testing.T) {
 	require.NoError(t, err)
 
 
-	err = store.ResetDeposits(ctx, 1, 0, nil)
+	err = store.ResetDeposits(ctx, 1, 0, 1, nil)
 	require.Error(t, err)
 	d, err := store.GetNumberDeposits(ctx, 1, 1, nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint32(3), d)
-	err = store.ResetDeposits(ctx, 1, 1, nil)
+	err = store.ResetDeposits(ctx, 1, 1, 1, nil)
 	require.NoError(t, err)
 	d, err = store.GetNumberDeposits(ctx, 1, 1, nil)
 	require.NoError(t, err)
@@ -351,8 +351,9 @@ func TestAddBackwardLET(t *testing.T) {
     	NewDepositCount: 1,
     	NewRoot: common.HexToHash("0xAA82FACE883070640F802CE8A2C42593AA18D3A691C61BA006EC477D6E5FEECC"),
 	}
-	err = store.AddBackwardLET(ctx, bLET, nil)
+	id, err := store.AddBackwardLET(ctx, bLET, nil)
 	require.NoError(t, err)
+	assert.NotZero(t, id)
 
 	var count uint32
 	selectCount := "SELECT count(*) FROM sync.backward_let"

--- a/db/pgstorage/pgstorage_test.go
+++ b/db/pgstorage/pgstorage_test.go
@@ -538,3 +538,187 @@ func TestDeleteClaimByGlobalIndex(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(2), count)
 }
+
+func TestGetAndDeleteOrphanDepositBackups(t *testing.T) {
+	dbCfg := NewConfigFromEnv()
+	ctx := context.Background()
+	err := InitOrReset(ctx, dbCfg)
+	require.NoError(t, err)
+
+	store, err := NewPostgresStorage(ctx, dbCfg)
+	require.NoError(t, err)
+
+	// Setup: Create blocks
+	// Blocks 1-6: Original blocks where deposits were synced (deposit_cnt 0-5)
+	// Block 7: First backward_let event
+	// Block 8: Second backward_let event
+	blocksData := `
+	INSERT INTO sync.block (id, block_num, block_hash, network_id)
+	VALUES(1, 100, decode('AA01033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C01','hex'), 1),
+	      (2, 101, decode('AA02033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C02','hex'), 1),
+	      (3, 102, decode('AA03033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C03','hex'), 1),
+	      (4, 103, decode('AA04033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C04','hex'), 1),
+	      (5, 104, decode('AA05033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C05','hex'), 1),
+	      (6, 105, decode('AA06033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C06','hex'), 1),
+	      (7, 200, decode('AAAA033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C07','hex'), 1),
+	      (8, 201, decode('BBBB033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C08','hex'), 1);
+	`
+	_, err = store.Exec(ctx, blocksData)
+	require.NoError(t, err)
+
+	// Simulate: Originally we had 10 deposits (deposit_cnt 0-9)
+	// First backward_let: previous_deposit_cnt=9, new_deposit_cnt=7 (deleted deposits 8,9)
+	firstBackwardLET := &etherman.BackwardLET{
+		BlockID:              7,
+		PreviousDepositCount: 9,
+		PreviousRoot:         common.HexToHash("0x1111FACE883070640F802CE8A2C42593AA18D3A691C61BA006EC477D6E5FEE1F"),
+		NewDepositCount:      7,
+		NewRoot:              common.HexToHash("0x2222FACE883070640F802CE8A2C42593AA18D3A691C61BA006EC477D6E5FEE2F"),
+	}
+	backwardLetID1, err := store.AddBackwardLET(ctx, firstBackwardLET, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), backwardLetID1)
+
+	// Second backward_let: previous_deposit_cnt=7, new_deposit_cnt=2 (deleted deposits 3,4,5,6,7)
+	secondBackwardLET := &etherman.BackwardLET{
+		BlockID:              8,
+		PreviousDepositCount: 7,
+		PreviousRoot:         common.HexToHash("0x2222FACE883070640F802CE8A2C42593AA18D3A691C61BA006EC477D6E5FEE2F"),
+		NewDepositCount:      2,
+		NewRoot:              common.HexToHash("0x3333FACE883070640F802CE8A2C42593AA18D3A691C61BA006EC477D6E5FEE3F"),
+	}
+	backwardLetID2, err := store.AddBackwardLET(ctx, secondBackwardLET, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), backwardLetID2)
+
+	// Insert deposit_backup entries for both backward_let events
+	// Deposits backed up by first backward_let (backward_let_id=1)
+	// These deposit_backups has the block_id of the original deposit. I mean the block_id where the deposit was synced. Not the block_id of the block where the backward_let event was synced
+	depositBackupData1 := `
+	INSERT INTO sync.deposit_backup(leaf_type, network_id, orig_net, orig_addr, amount, dest_net, dest_addr, block_id, deposit_cnt, tx_hash, metadata, ready_for_claim, backward_let_id)
+	VALUES(0, 1, 0, decode('A9B5033799ADF3739383A0489EFBE8A0D4D5E447','hex'), '8000000000000000000', 0, decode('B9B5033799ADF3739383A0489EFBE8A0D4D5E458','hex'), 1, 0, decode('C9B5033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C10','hex'), decode('','hex'), true, 1),
+	      (0, 1, 0, decode('A9B5033799ADF3739383A0489EFBE8A0D4D5E448','hex'), '9000000000000000000', 0, decode('B9B5033799ADF3739383A0489EFBE8A0D4D5E459','hex'), 2, 1, decode('C9B5033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C11','hex'), decode('','hex'), true, 1);
+	`
+	_, err = store.Exec(ctx, depositBackupData1)
+	require.NoError(t, err)
+
+	// Deposits backed up by second backward_let (backward_let_id=2)
+	depositBackupData2 := `
+	INSERT INTO sync.deposit_backup(leaf_type, network_id, orig_net, orig_addr, amount, dest_net, dest_addr, block_id, deposit_cnt, tx_hash, metadata, ready_for_claim, backward_let_id)
+	VALUES(0, 1, 0, decode('A9B5033799ADF3739383A0489EFBE8A0D4D5E546','hex'), '3000000000000000000', 0, decode('B9B5033799ADF3739383A0489EFBE8A0D4D5E481','hex'), 3, 2, decode('C9B5033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C12','hex'), decode('','hex'), true, 2);
+
+	INSERT INTO sync.deposit_backup(leaf_type, network_id, orig_net, orig_addr, amount, dest_net, dest_addr, block_id, deposit_cnt, tx_hash, metadata, ready_for_claim, backward_let_id)
+	VALUES(0, 1, 0, decode('A9B5033799ADF3739383A0489EFBE8A0D4D5E547','hex'), '4000000000000000000', 0, decode('B9B5033799ADF3739383A0489EFBE8A0D4D5E482','hex'), 4, 3, decode('C9B5033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C13','hex'), decode('','hex'), true, 2);
+
+	INSERT INTO sync.deposit_backup(leaf_type, network_id, orig_net, orig_addr, amount, dest_net, dest_addr, block_id, deposit_cnt, tx_hash, metadata, ready_for_claim, backward_let_id)
+	VALUES(0, 1, 0, decode('A9B5033799ADF3739383A0489EFBE8A0D4D5E548','hex'), '5000000000000000000', 0, decode('B9B5033799ADF3739383A0489EFBE8A0D4D5E483','hex'), 5, 4, decode('C9B5033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C14','hex'), decode('','hex'), false, 2);
+
+	INSERT INTO sync.deposit_backup(leaf_type, network_id, orig_net, orig_addr, amount, dest_net, dest_addr, block_id, deposit_cnt, tx_hash, metadata, ready_for_claim, backward_let_id)
+	VALUES(0, 1, 0, decode('A9B5033799ADF3739383A0489EFBE8A0D4D5E549','hex'), '6000000000000000000', 0, decode('B9B5033799ADF3739383A0489EFBE8A0D4D5E484','hex'), 6, 5, decode('C9B5033799ADF3739383A0489EFBE8A0D4D5E4478778A4F4304562FD51AE4C15','hex'), decode('','hex'), true, 2);
+	`
+	_, err = store.Exec(ctx, depositBackupData2)
+	require.NoError(t, err)
+
+	// Verify initial state: should have 6 deposit_backup entries (2 from first backward_let + 4 from second)
+	var initialCount uint32
+	err = store.QueryRow(ctx, "SELECT count(*) FROM sync.deposit_backup").Scan(&initialCount)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(6), initialCount, "Should have 6 deposit_backup entries initially")
+
+	// Verify we have 2 backward_let entries
+	var backwardLetCount uint32
+	err = store.QueryRow(ctx, "SELECT count(*) FROM sync.backward_let").Scan(&backwardLetCount)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), backwardLetCount, "Should have 2 backward_let entries")
+
+	// Now delete block 8 which should trigger CASCADE delete on second backward_let
+	// This will make the 4 deposits associated with backward_let_id=2 orphans
+	deleteBlock := "DELETE FROM sync.block WHERE id = 8"
+	_, err = store.Exec(ctx, deleteBlock)
+	require.NoError(t, err)
+
+	// Verify backward_let with id=2 was deleted (CASCADE)
+	err = store.QueryRow(ctx, "SELECT count(*) FROM sync.backward_let").Scan(&backwardLetCount)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), backwardLetCount, "Should have only 1 backward_let entry after cascade delete")
+
+	// Verify the remaining backward_let is id=1
+	var remainingBackwardLetID uint64
+	err = store.QueryRow(ctx, "SELECT id FROM sync.backward_let").Scan(&remainingBackwardLetID)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), remainingBackwardLetID, "Remaining backward_let should have id=1")
+
+	// Now the 4 deposits with backward_let_id=2 are orphans
+	// Run GetAndDeleteOrphanDepositBackups to find and delete them
+	orphanDeposits, err := store.GetAndDeleteOrphanDepositBackups(ctx, nil)
+	require.NoError(t, err)
+
+	// Verify that 4 orphan deposits were returned
+	assert.Equal(t, 4, len(orphanDeposits), "Should return 4 orphan deposits")
+
+	// Verify the orphan deposits have the expected amounts (3000-6000 ETH)
+	expectedAmounts := map[string]bool{
+		"3000000000000000000": false,
+		"4000000000000000000": false,
+		"5000000000000000000": false,
+		"6000000000000000000": false,
+	}
+	for i, dep := range orphanDeposits {
+		amountStr := dep.Amount.String()
+		if _, exists := expectedAmounts[amountStr]; exists {
+			expectedAmounts[amountStr] = true
+		}
+		assert.Equal(t, uint32(1), dep.NetworkID, "NetworkID should be 1")
+		assert.Equal(t, uint32(i)+2, dep.DepositCount, "BlockID should be different")
+		assert.Equal(t, uint32(0), dep.DestinationNetwork, "DestinationNetwork should be 0")
+	}
+
+	// Verify all expected amounts were found
+	for amount, found := range expectedAmounts {
+		assert.True(t, found, "Should have found orphan deposit with amount %s", amount)
+	}
+
+	// Verify that orphan deposits were deleted: should have only 2 deposit_backup entries remaining
+	var finalCount uint32
+	err = store.QueryRow(ctx, "SELECT count(*) FROM sync.deposit_backup").Scan(&finalCount)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), finalCount, "Should have only 2 valid deposit_backup entries remaining")
+
+	// Verify the remaining deposits have valid backward_let_id=1
+	var remainingBackwardLetIDs []int64
+	rows, err := store.Query(ctx, "SELECT backward_let_id FROM sync.deposit_backup ORDER BY deposit_cnt")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	for rows.Next() {
+		var backwardLetID int64
+		err = rows.Scan(&backwardLetID)
+		require.NoError(t, err)
+		remainingBackwardLetIDs = append(remainingBackwardLetIDs, backwardLetID)
+	}
+	assert.Equal(t, []int64{1, 1}, remainingBackwardLetIDs, "All remaining deposits should reference backward_let_id=1")
+
+	// Verify deposit_cnt of remaining deposits (should be 0 and 1)
+	var depositCounts []uint32
+	rows2, err := store.Query(ctx, "SELECT deposit_cnt FROM sync.deposit_backup ORDER BY deposit_cnt")
+	require.NoError(t, err)
+	defer rows2.Close()
+
+	for rows2.Next() {
+		var depositCnt uint32
+		err = rows2.Scan(&depositCnt)
+		require.NoError(t, err)
+		depositCounts = append(depositCounts, depositCnt)
+	}
+	assert.Equal(t, []uint32{0, 1}, depositCounts, "Remaining deposits should have deposit_cnt 0 and 1")
+
+	// Test that running GetAndDeleteOrphanDepositBackups again returns no orphans
+	orphanDeposits2, err := store.GetAndDeleteOrphanDepositBackups(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(orphanDeposits2), "Should return 0 orphan deposits on second run")
+
+	// Verify count is still 2
+	err = store.QueryRow(ctx, "SELECT count(*) FROM sync.deposit_backup").Scan(&finalCount)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), finalCount, "Should still have 2 deposit_backup entries")
+}

--- a/synchronizer/interfaces.go
+++ b/synchronizer/interfaces.go
@@ -30,7 +30,7 @@ type storageInterface interface {
 	Reset(ctx context.Context, blockNumber uint64, networkID uint32, dbTx interface{}) error
 	GetPreviousBlock(ctx context.Context, networkID uint32, offset uint64, dbTx interface{}) (etherman.Block, error)
 	GetNumberDeposits(ctx context.Context, origNetworkID uint32, blockNumber uint64, dbTx interface{}) (uint32, error)
-	ResetDeposits(ctx context.Context, depositCount uint32, networkID uint32, dbTx interface{}) error
+	ResetDeposits(ctx context.Context, depositCount uint32, networkID uint32, backwardLETID uint64, dbTx interface{}) error
 	AddTrustedGlobalExitRoot(ctx context.Context, trustedExitRoot *etherman.GlobalExitRoot, dbTx interface{}) (bool, error)
 	GetLatestL1SyncedExitRoot(ctx context.Context, dbTx interface{}) (*etherman.GlobalExitRoot, error)
 	GetLatestTrustedExitRoot(ctx context.Context, networkID uint32, dbTx interface{}) (*etherman.GlobalExitRoot, error)
@@ -40,7 +40,7 @@ type storageInterface interface {
 	UpdateL2GER(ctx context.Context, ger etherman.GlobalExitRoot, dbTx interface{}) error
 	AddRemoveL2GER(ctx context.Context, globalExitRoot etherman.GlobalExitRoot, dbTx interface{}) error
 	AddSyncStatus(ctx context.Context, syncStatus etherman.SyncStatus, dbTx interface{}) error
-	AddBackwardLET(ctx context.Context, backwardLET *etherman.BackwardLET, dbTx interface{}) error
+	AddBackwardLET(ctx context.Context, backwardLET *etherman.BackwardLET, dbTx interface{}) (uint64, error)
 	AddForwardLET(ctx context.Context, forwardLET *etherman.ForwardLET, dbTx interface{}) error
 	DeleteClaimByGlobalIndex(ctx context.Context, globalIndex *big.Int, networkID uint32, dbTx interface{}) error
 	AddUnsetClaim(ctx context.Context, unsetClaim *etherman.UnsetClaim, dbTx interface{}) error

--- a/synchronizer/interfaces.go
+++ b/synchronizer/interfaces.go
@@ -28,6 +28,7 @@ type storageInterface interface {
 	AddClaim(ctx context.Context, claim *etherman.Claim, dbTx interface{}) error
 	AddTokenWrapped(ctx context.Context, tokenWrapped *etherman.TokenWrapped, dbTx interface{}) error
 	Reset(ctx context.Context, blockNumber uint64, networkID uint32, dbTx interface{}) error
+	GetAndDeleteOrphanDepositBackups(ctx context.Context, dbTx interface{}) ([]*etherman.Deposit, error)
 	GetPreviousBlock(ctx context.Context, networkID uint32, offset uint64, dbTx interface{}) (etherman.Block, error)
 	GetNumberDeposits(ctx context.Context, origNetworkID uint32, blockNumber uint64, dbTx interface{}) (uint32, error)
 	ResetDeposits(ctx context.Context, depositCount uint32, networkID uint32, backwardLETID uint64, dbTx interface{}) error

--- a/synchronizer/mock_storage.go
+++ b/synchronizer/mock_storage.go
@@ -27,21 +27,31 @@ func (_m *storageMock) EXPECT() *storageMock_Expecter {
 }
 
 // AddBackwardLET provides a mock function with given fields: ctx, backwardLET, dbTx
-func (_m *storageMock) AddBackwardLET(ctx context.Context, backwardLET *etherman.BackwardLET, dbTx interface{}) error {
+func (_m *storageMock) AddBackwardLET(ctx context.Context, backwardLET *etherman.BackwardLET, dbTx interface{}) (uint64, error) {
 	ret := _m.Called(ctx, backwardLET, dbTx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AddBackwardLET")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *etherman.BackwardLET, interface{}) error); ok {
+	var r0 uint64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *etherman.BackwardLET, interface{}) (uint64, error)); ok {
+		return rf(ctx, backwardLET, dbTx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *etherman.BackwardLET, interface{}) uint64); ok {
 		r0 = rf(ctx, backwardLET, dbTx)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(uint64)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, *etherman.BackwardLET, interface{}) error); ok {
+		r1 = rf(ctx, backwardLET, dbTx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // storageMock_AddBackwardLET_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddBackwardLET'
@@ -64,12 +74,12 @@ func (_c *storageMock_AddBackwardLET_Call) Run(run func(ctx context.Context, bac
 	return _c
 }
 
-func (_c *storageMock_AddBackwardLET_Call) Return(_a0 error) *storageMock_AddBackwardLET_Call {
-	_c.Call.Return(_a0)
+func (_c *storageMock_AddBackwardLET_Call) Return(_a0 uint64, _a1 error) *storageMock_AddBackwardLET_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *storageMock_AddBackwardLET_Call) RunAndReturn(run func(context.Context, *etherman.BackwardLET, interface{}) error) *storageMock_AddBackwardLET_Call {
+func (_c *storageMock_AddBackwardLET_Call) RunAndReturn(run func(context.Context, *etherman.BackwardLET, interface{}) (uint64, error)) *storageMock_AddBackwardLET_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -845,6 +855,65 @@ func (_c *storageMock_DeleteClaimByGlobalIndex_Call) RunAndReturn(run func(conte
 	return _c
 }
 
+// GetAndDeleteOrphanDepositBackups provides a mock function with given fields: ctx, dbTx
+func (_m *storageMock) GetAndDeleteOrphanDepositBackups(ctx context.Context, dbTx interface{}) ([]*etherman.Deposit, error) {
+	ret := _m.Called(ctx, dbTx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAndDeleteOrphanDepositBackups")
+	}
+
+	var r0 []*etherman.Deposit
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}) ([]*etherman.Deposit, error)); ok {
+		return rf(ctx, dbTx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}) []*etherman.Deposit); ok {
+		r0 = rf(ctx, dbTx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*etherman.Deposit)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, interface{}) error); ok {
+		r1 = rf(ctx, dbTx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// storageMock_GetAndDeleteOrphanDepositBackups_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAndDeleteOrphanDepositBackups'
+type storageMock_GetAndDeleteOrphanDepositBackups_Call struct {
+	*mock.Call
+}
+
+// GetAndDeleteOrphanDepositBackups is a helper method to define mock.On call
+//   - ctx context.Context
+//   - dbTx interface{}
+func (_e *storageMock_Expecter) GetAndDeleteOrphanDepositBackups(ctx interface{}, dbTx interface{}) *storageMock_GetAndDeleteOrphanDepositBackups_Call {
+	return &storageMock_GetAndDeleteOrphanDepositBackups_Call{Call: _e.mock.On("GetAndDeleteOrphanDepositBackups", ctx, dbTx)}
+}
+
+func (_c *storageMock_GetAndDeleteOrphanDepositBackups_Call) Run(run func(ctx context.Context, dbTx interface{})) *storageMock_GetAndDeleteOrphanDepositBackups_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(interface{}))
+	})
+	return _c
+}
+
+func (_c *storageMock_GetAndDeleteOrphanDepositBackups_Call) Return(_a0 []*etherman.Deposit, _a1 error) *storageMock_GetAndDeleteOrphanDepositBackups_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *storageMock_GetAndDeleteOrphanDepositBackups_Call) RunAndReturn(run func(context.Context, interface{}) ([]*etherman.Deposit, error)) *storageMock_GetAndDeleteOrphanDepositBackups_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetDeposit provides a mock function with given fields: ctx, depositCounter, networkID, dbTx
 func (_m *storageMock) GetDeposit(ctx context.Context, depositCounter uint32, networkID uint32, dbTx interface{}) (*etherman.Deposit, error) {
 	ret := _m.Called(ctx, depositCounter, networkID, dbTx)
@@ -1372,17 +1441,17 @@ func (_c *storageMock_Reset_Call) RunAndReturn(run func(context.Context, uint64,
 	return _c
 }
 
-// ResetDeposits provides a mock function with given fields: ctx, depositCount, networkID, dbTx
-func (_m *storageMock) ResetDeposits(ctx context.Context, depositCount uint32, networkID uint32, dbTx interface{}) error {
-	ret := _m.Called(ctx, depositCount, networkID, dbTx)
+// ResetDeposits provides a mock function with given fields: ctx, depositCount, networkID, backwardLETID, dbTx
+func (_m *storageMock) ResetDeposits(ctx context.Context, depositCount uint32, networkID uint32, backwardLETID uint64, dbTx interface{}) error {
+	ret := _m.Called(ctx, depositCount, networkID, backwardLETID, dbTx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ResetDeposits")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32, interface{}) error); ok {
-		r0 = rf(ctx, depositCount, networkID, dbTx)
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, uint32, uint64, interface{}) error); ok {
+		r0 = rf(ctx, depositCount, networkID, backwardLETID, dbTx)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1399,14 +1468,15 @@ type storageMock_ResetDeposits_Call struct {
 //   - ctx context.Context
 //   - depositCount uint32
 //   - networkID uint32
+//   - backwardLETID uint64
 //   - dbTx interface{}
-func (_e *storageMock_Expecter) ResetDeposits(ctx interface{}, depositCount interface{}, networkID interface{}, dbTx interface{}) *storageMock_ResetDeposits_Call {
-	return &storageMock_ResetDeposits_Call{Call: _e.mock.On("ResetDeposits", ctx, depositCount, networkID, dbTx)}
+func (_e *storageMock_Expecter) ResetDeposits(ctx interface{}, depositCount interface{}, networkID interface{}, backwardLETID interface{}, dbTx interface{}) *storageMock_ResetDeposits_Call {
+	return &storageMock_ResetDeposits_Call{Call: _e.mock.On("ResetDeposits", ctx, depositCount, networkID, backwardLETID, dbTx)}
 }
 
-func (_c *storageMock_ResetDeposits_Call) Run(run func(ctx context.Context, depositCount uint32, networkID uint32, dbTx interface{})) *storageMock_ResetDeposits_Call {
+func (_c *storageMock_ResetDeposits_Call) Run(run func(ctx context.Context, depositCount uint32, networkID uint32, backwardLETID uint64, dbTx interface{})) *storageMock_ResetDeposits_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(uint32), args[2].(uint32), args[3].(interface{}))
+		run(args[0].(context.Context), args[1].(uint32), args[2].(uint32), args[3].(uint64), args[4].(interface{}))
 	})
 	return _c
 }
@@ -1416,7 +1486,7 @@ func (_c *storageMock_ResetDeposits_Call) Return(_a0 error) *storageMock_ResetDe
 	return _c
 }
 
-func (_c *storageMock_ResetDeposits_Call) RunAndReturn(run func(context.Context, uint32, uint32, interface{}) error) *storageMock_ResetDeposits_Call {
+func (_c *storageMock_ResetDeposits_Call) RunAndReturn(run func(context.Context, uint32, uint32, uint64, interface{}) error) *storageMock_ResetDeposits_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -686,6 +686,21 @@ func (s *ClientSynchronizer) resetState(blockNumber uint64) error {
 		log.Errorf("networkID: %d, error resetting ReorgMT the state. Error: %v", s.networkID, err)
 		return s.rollback(blockNumber, err, dbTx)
 	}
+
+	// Read orphan depositBackups and process them
+	depositsToRestore, err := s.storage.GetAndDeleteOrphanDepositBackups(s.ctx, dbTx)
+	if err != nil {
+		log.Errorf("networkID: %d, error getting orphan deposit backups. Error: %v", s.networkID, err)
+		return s.rollback(blockNumber, err, dbTx)
+	}
+	for _, deposit := range depositsToRestore {
+		err := s.processDeposit(*deposit, deposit.BlockID, dbTx)
+		if err != nil {
+			log.Errorf("networkID: %d, error processing orphan deposit: %+v Error: %s", s.networkID, deposit, err.Error())
+			return s.rollback(blockNumber, err, dbTx)
+		}
+	}
+
 	err = s.storage.Commit(s.ctx, dbTx)
 	if err != nil {
 		log.Errorf("networkID: %d, error committing the resetted state. Error: %v", s.networkID, err)

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -915,6 +915,12 @@ func (s *ClientSynchronizer) processRemoveL2GlobalExitRoot(ger etherman.GlobalEx
 func (s *ClientSynchronizer) processBackwardLETSovereign(backwardLET etherman.BackwardLET, blockID, blockNumber uint64, dbTx interface{}) error {
 	backwardLET.BlockID = blockID
 	log.Debugf("networkID: %d, Full BackwardLET event: %+v", s.networkID, backwardLET)
+	// Store the backwardLET event in the db
+	backwardLETID, err := s.storage.AddBackwardLET(s.ctx, &backwardLET, dbTx)
+	if err != nil {
+		log.Errorf("networkID: %d, error adding BackwardLET to the state. Error: %v", s.networkID, err)
+		return s.rollback(blockNumber, err, dbTx)
+	}
 	// First check the initial state of the MT
 	depositCnt, err := s.storage.GetNumberDeposits(s.ctx, s.networkID, blockNumber, dbTx)
 	if err != nil {
@@ -934,8 +940,8 @@ func (s *ClientSynchronizer) processBackwardLETSovereign(backwardLET etherman.Ba
 		return s.rollback(blockNumber, err, dbTx)
 	}
 	// MT entries are deleted in cascade when invalid deposits are deleted.
-	// Remove the deposits that are no longer valid (deposit_cnt >= backwardLET.NewDepositCount)
-	err = s.storage.ResetDeposits(s.ctx, backwardLET.NewDepositCount, s.networkID, dbTx)
+	// Remove the deposits that are no longer valid (deposit_cnt >= backwardLET.NewDepositCount) and save them in another db table
+	err = s.storage.ResetDeposits(s.ctx, backwardLET.NewDepositCount, s.networkID, backwardLETID, dbTx)
 	if err != nil {
 		log.Errorf("networkID: %d, error reseting deposits in processBackwardLETSovereign. Error: %v", s.networkID, err)
 		return s.rollback(blockNumber, err, dbTx)
@@ -962,12 +968,6 @@ func (s *ClientSynchronizer) processBackwardLETSovereign(backwardLET etherman.Ba
 		err := fmt.Errorf("networkID: %d, error processing BackwardLET. NewRoot or NewDepositCount do not match with the current state after reseting the state. Current localExitTreeRoot: %s, BackwardLET.NewRoot: %s, Current depositCnt: %d, BackwardLET.NewDepositCount: %d",
 			s.networkID, localExitTreeRoot.String(), backwardLET.NewRoot.String(), depositCnt, backwardLET.NewDepositCount)
 		log.Error(err)
-		return s.rollback(blockNumber, err, dbTx)
-	}
-	// Store the backwardLET event in the db
-	err = s.storage.AddBackwardLET(s.ctx, &backwardLET, dbTx)
-	if err != nil {
-		log.Errorf("networkID: %d, error adding BackwardLET to the state. Error: %v", s.networkID, err)
 		return s.rollback(blockNumber, err, dbTx)
 	}
 	return nil

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -529,6 +529,11 @@ func TestReorg(t *testing.T) {
 			Once()
 
 		m.Storage.
+			On("GetAndDeleteOrphanDepositBackups", ctx, m.DbTx).
+			Return([]*etherman.Deposit{}, nil).
+			Once()
+
+		m.Storage.
 			On("Commit", ctx, m.DbTx).
 			Return(nil).
 			Once()
@@ -756,6 +761,11 @@ func TestLatestSyncedBlockEmpty(t *testing.T) {
 			Once()
 
 		m.Storage.
+			On("GetAndDeleteOrphanDepositBackups", ctx, m.DbTx).
+			Return([]*etherman.Deposit{}, nil).
+			Once()
+
+		m.Storage.
 			On("Commit", ctx, m.DbTx).
 			Return(nil).
 			Once()
@@ -909,6 +919,11 @@ func TestRegularReorg(t *testing.T) {
 		m.BridgeCtrl.
 			On("ReorgMT", ctx, depositCnt, networkID, m.DbTx).
 			Return(nil).
+			Once()
+
+		m.Storage.
+			On("GetAndDeleteOrphanDepositBackups", ctx, m.DbTx).
+			Return([]*etherman.Deposit{}, nil).
 			Once()
 
 		m.Storage.
@@ -1145,6 +1160,11 @@ func TestLatestSyncedBlockEmptyWithExtraReorg(t *testing.T) {
 			Once()
 
 		m.Storage.
+			On("GetAndDeleteOrphanDepositBackups", ctx, m.DbTx).
+			Return([]*etherman.Deposit{}, nil).
+			Once()
+
+		m.Storage.
 			On("Commit", ctx, m.DbTx).
 			Return(nil).
 			Once()
@@ -1341,6 +1361,11 @@ func TestCallFromEmptyBlockAndReorg(t *testing.T) {
 		m.BridgeCtrl.
 			On("ReorgMT", ctx, depositCnt, networkID, m.DbTx).
 			Return(nil).
+			Once()
+
+		m.Storage.
+			On("GetAndDeleteOrphanDepositBackups", ctx, m.DbTx).
+			Return([]*etherman.Deposit{}, nil).
 			Once()
 
 		m.Storage.

--- a/test/benchmark/api_test.go
+++ b/test/benchmark/api_test.go
@@ -78,19 +78,19 @@ func initServer(b *testing.B, bench benchmark) *bridgectrl.BridgeController {
 		networkID := uint32(rand.Intn(2)) //nolint: gosec
 		dbTx, err := store.BeginDBTransaction(context.Background())
 		require.NoError(b, err)
-		id, err := store.AddBlock(context.TODO(), &etherman.Block{
+		id, err := store.AddBlock(ctx, &etherman.Block{
 			BlockNumber: uint64(i), // nolint:gosec
 			BlockHash:   utils.GenerateRandomHash(),
 		}, dbTx)
 		require.NoError(b, err)
 		deposit := randDeposit(r, counts[networkID], id, networkID)
 		counts[networkID]++
-		depositID, err := store.AddDeposit(context.TODO(), deposit, dbTx)
+		depositID, err := store.AddDeposit(ctx, deposit, dbTx)
 		require.NoError(b, err)
 		deposit.Id = depositID
 		require.NoError(b, bt.AddDeposit(ctx, deposit, dbTx))
 		if i > bench.initSize {
-			require.NoError(b, store.Commit(context.TODO(), dbTx))
+			require.NoError(b, store.Commit(ctx, dbTx))
 			continue
 		}
 		var roots [2][]byte
@@ -100,14 +100,14 @@ func initServer(b *testing.B, bench benchmark) *bridgectrl.BridgeController {
 		require.NoError(b, err)
 
 		if networkID == 0 {
-			err = store.AddGlobalExitRoot(context.TODO(), &etherman.GlobalExitRoot{
+			err = store.AddGlobalExitRoot(ctx, &etherman.GlobalExitRoot{
 				GlobalExitRoot: bridgectrl.Hash(common.BytesToHash(roots[0]), common.BytesToHash(roots[1])),
 				ExitRoots:      []common.Hash{common.BytesToHash(roots[0]), common.BytesToHash(roots[1])},
 				BlockID:        id,
 			}, dbTx)
 		} else {
 			var isUpdated bool
-			isUpdated, err = store.AddTrustedGlobalExitRoot(context.TODO(), &etherman.GlobalExitRoot{
+			isUpdated, err = store.AddTrustedGlobalExitRoot(ctx, &etherman.GlobalExitRoot{
 				NetworkID:      1,
 				GlobalExitRoot: bridgectrl.Hash(common.BytesToHash(roots[0]), common.BytesToHash(roots[1])),
 				ExitRoots:      []common.Hash{common.BytesToHash(roots[0]), common.BytesToHash(roots[1])},
@@ -115,7 +115,7 @@ func initServer(b *testing.B, bench benchmark) *bridgectrl.BridgeController {
 			require.True(b, isUpdated)
 		}
 		require.NoError(b, err)
-		err = store.AddClaim(context.TODO(), &etherman.Claim{
+		err = store.AddClaim(ctx, &etherman.Claim{
 			Index:              deposit.DepositCount,
 			OriginalNetwork:    deposit.OriginalNetwork,
 			Amount:             deposit.Amount,
@@ -126,10 +126,10 @@ func initServer(b *testing.B, bench benchmark) *bridgectrl.BridgeController {
 			BlockID:            id,
 		}, dbTx)
 		require.NoError(b, err)
-		require.NoError(b, store.Commit(context.TODO(), dbTx))
+		require.NoError(b, store.Commit(ctx, dbTx))
 	}
 
-	require.NoError(b, store.UpdateDepositsStatusForTesting(context.TODO(), nil))
+	require.NoError(b, store.UpdateDepositsStatusForTesting(ctx, nil))
 
 	return bt
 }
@@ -143,7 +143,7 @@ func addDeposit(b *testing.B, bench benchmark) {
 	var deposits []*etherman.Deposit
 	for i := 0; i < bench.initSize; i++ {
 		deposit := randDeposit(r, uint32(i), 0, 0) // nolint:gosec
-		depositID, err := store.AddDeposit(context.TODO(), deposit, nil)
+		depositID, err := store.AddDeposit(ctx, deposit, nil)
 		require.NoError(b, err)
 		deposit.Id = depositID
 		deposits = append(deposits, deposit)
@@ -153,7 +153,7 @@ func addDeposit(b *testing.B, bench benchmark) {
 		dbTx, err := store.BeginDBTransaction(context.Background())
 		require.NoError(b, err)
 		require.NoError(b, bt.AddDeposit(ctx, deposits[i], dbTx))
-		require.NoError(b, store.Commit(context.TODO(), dbTx))
+		require.NoError(b, store.Commit(ctx, dbTx))
 	}
 }
 

--- a/test/e2e/bridge_network_bridge_msg_test.go
+++ b/test/e2e/bridge_network_bridge_msg_test.go
@@ -32,7 +32,7 @@ func TestMessageTransferL1toL2(t *testing.T) {
 		t.Skip()
 	}
 	log.Infof("Starting test bridge_message L1 -> L2")
-	ctx := context.TODO()
+	ctx := context.Background()
 	testData, err := NewBridge2e2TestData(ctx, nil)
 	require.NoError(t, err)
 	balances, err := getcurrentBalance(ctx, testData)
@@ -67,7 +67,7 @@ func TestMessageTransferL2toL1(t *testing.T) {
 		t.Skip()
 	}
 	log.Infof("Starting test bridge_message L2 -> L1")
-	ctx := context.TODO()
+	ctx := context.Background()
 	testData, err := NewBridge2e2TestData(ctx, nil)
 	require.NoError(t, err)
 	log.Infof("MSG [L2->L1]  deploying contract to L1 to recieve message")

--- a/test/e2e/bridge_network_erc20_test.go
+++ b/test/e2e/bridge_network_erc20_test.go
@@ -24,7 +24,7 @@ func TestERC20TransferL1toL2(t *testing.T) {
 		t.Skip()
 	}
 	log.Infof("Starting test ERC20 L1 -> L2")
-	ctx := context.TODO()
+	ctx := context.Background()
 	testData, err := NewBridge2e2TestData(ctx, nil)
 	require.NoError(t, err)
 	balances, err := getcurrentBalance(ctx, testData)
@@ -59,7 +59,7 @@ func TestERC20TransferL2toL1(t *testing.T) {
 	}
 	log.Infof("Starting test ERC20 L2->L1")
 
-	ctx := context.TODO()
+	ctx := context.Background()
 	testData, err := NewBridge2e2TestData(ctx, nil)
 	require.NoError(t, err)
 	balances, err := getcurrentBalance(ctx, testData)

--- a/test/e2e/bridge_network_eth_test.go
+++ b/test/e2e/bridge_network_eth_test.go
@@ -18,7 +18,7 @@ func TestClaimAlreadyClaimedDepositL2toL1(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := context.TODO()
+	ctx := context.Background()
 	testData, err := NewBridge2e2TestData(ctx, nil)
 	require.NoError(t, err)
 	checkBridgeServiceIsAliveAndExpectedVersion(t, testData)
@@ -52,7 +52,7 @@ func TestEthTransferL1toL2(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	ctx := context.TODO()
+	ctx := context.Background()
 	testData, err := NewBridge2e2TestData(ctx, nil)
 	require.NoError(t, err)
 	checkBridgeServiceIsAliveAndExpectedVersion(t, testData)
@@ -82,7 +82,7 @@ func TestEthTransferL2toL1(t *testing.T) {
 		t.Skip()
 	}
 
-	ctx := context.TODO()
+	ctx := context.Background()
 	testData, err := NewBridge2e2TestData(ctx, nil)
 	require.NoError(t, err)
 


### PR DESCRIPTION
### What does this PR do?

Fixes a bug reorging the backwardLET event. Deposits were not restored properly