### PR TITLE
fix: handle duplicate claim inserts in AddClaim with ON CONFLICT

### DIFF
--- a/db/pgstorage/pgstorage.go
+++ b/db/pgstorage/pgstorage.go
@@ -129,7 +129,7 @@ func (p *PostgresStorage) AddDeposit(ctx context.Context, deposit *etherman.Depo
 
 // AddClaim adds new claim to the storage.
 func (p *PostgresStorage) AddClaim(ctx context.Context, claim *etherman.Claim, dbTx interface{}) error {
-	const addClaimSQL = "INSERT INTO sync.claim (network_id, index, orig_net, orig_addr, amount, dest_addr, block_id, tx_hash, rollup_index, mainnet_flag, global_index) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"
+	const addClaimSQL = "INSERT INTO sync.claim (network_id, index, orig_net, orig_addr, amount, dest_addr, block_id, tx_hash, rollup_index, mainnet_flag, global_index) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) ON CONFLICT (index, rollup_index, network_id, mainnet_flag) DO NOTHING"
 	e := p.getExecQuerier(dbTx)
 	_, err := e.Exec(ctx, addClaimSQL, claim.NetworkID, claim.Index, claim.OriginalNetwork, claim.OriginalAddress, claim.Amount.String(), claim.DestinationAddress, claim.BlockID, claim.TxHash, claim.RollupIndex, claim.MainnetFlag, claim.GlobalIndex)
 	return err


### PR DESCRIPTION
## Problem

`AddClaim()` in `db/pgstorage/pgstorage.go` uses a bare `INSERT` that fails with `duplicate key value violates unique constraint "claim_pkey"` when the same claim is processed twice by the L2 synchronizer.

This happens when block processing partially succeeds (claim inserted and committed) but then fails on a subsequent operation within the same block. The synchronizer considers the block unprocessed and retries it, but the claim row already exists from the first attempt. The resulting PK violation is treated as a fatal sync error, causing an infinite retry loop that **permanently blocks all L2 sync progress**.

### Impact

When this occurs, the L2 synchronizer can never advance past the affected block. This means:
- No new L2 deposits are indexed
- No new claims are tracked  
- Bridge-out deposits are never marked as `ready_for_claim`
- The entire L2→L1 bridge flow stops

### Reproduction

This reliably reproduces when integrating with sovereign chains (e.g., Miden via the agglayer proxy) where `ClaimEvent` logs are emitted as synthetic EVM events. The L2 sync processes the `ClaimEvent`, inserts the claim, then hits an unrelated error in the same block batch, triggering the retry → duplicate → deadlock cycle.

## Fix

Add `ON CONFLICT (index, rollup_index, network_id, mainnet_flag) DO NOTHING` to the `INSERT` statement in `AddClaim()`. This matches the table's composite primary key (established in migration `0014.sql`). Duplicate inserts are silently ignored since the claim data is identical across processing attempts.

## Test plan

- [ ] Verify existing unit tests pass
- [ ] Verify L2 sync no longer deadlocks on duplicate claims
- [ ] Verify claims are still correctly stored on first insert