### PR TITLE
fix: merkle-proof-by-ger returns a proof for deposits not in the tree (off-by-one)

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -301,10 +301,6 @@ func (s *bridgeService) GetClaimProofForCompressed(ctx context.Context, ger comm
 		rollupLeaf        common.Hash
 	)
 	if networkID == 0 { // Mainnet
-		if err := s.checkDepositIncludedInRoot(ctx, depositCnt, networkID, globalExitRoot.ExitRoots[0], dbTx); err != nil {
-			log.Errorf("deposit not included in root. Error: %v", err)
-			return nil, nil, nil, err
-		}
 		merkleProof, err = s.getProof(ctx, depositCnt, globalExitRoot.ExitRoots[0], dbTx)
 		if err != nil {
 			log.Error("error getting merkleProof. Error: ", err)
@@ -316,10 +312,6 @@ func (s *bridgeService) GetClaimProofForCompressed(ctx context.Context, ger comm
 		if err != nil {
 			log.Error("error getting rollupProof. Error: ", err)
 			return nil, nil, nil, fmt.Errorf("getting the rollup proof failed, error: %v, network: %d", err, networkID)
-		}
-		if err := s.checkDepositIncludedInRoot(ctx, depositCnt, networkID, rollupLeaf, dbTx); err != nil {
-			log.Errorf("deposit not included in root. Error: %v", err)
-			return nil, nil, nil, err
 		}
 		merkleProof, err = s.getProof(ctx, depositCnt, rollupLeaf, dbTx)
 		if err != nil {
@@ -506,7 +498,7 @@ func (s *bridgeService) GetProof(ctx context.Context, req *pb.GetProofRequest) (
 		proof       []string
 		rollupProof []string
 	)
-	if len(merkleProof) != len(rollupMerkleProof) {
+	if len(proof) != len(rollupProof) {
 		return nil, fmt.Errorf("proofs have different lengths. MerkleProof: %d. RollupMerkleProof: %d", len(merkleProof), len(rollupMerkleProof))
 	}
 	for i := 0; i < len(merkleProof); i++ {
@@ -697,7 +689,7 @@ func (s *bridgeService) GetProofV2(ctx context.Context, req *pb.GetProofV2Reques
 		proof       []string
 		rollupProof []string
 	)
-	if len(merkleProof) != len(rollupMerkleProof) {
+	if len(proof) != len(rollupProof) {
 		return nil, fmt.Errorf("proofs have different lengths. MerkleProof: %d. RollupMerkleProof: %d", len(merkleProof), len(rollupMerkleProof))
 	}
 	for i := 0; i < len(merkleProof); i++ {

--- a/server/service.go
+++ b/server/service.go
@@ -203,6 +203,23 @@ func (s *bridgeService) GetClaimProof(ctx context.Context, depositCnt, networkID
 	return globalExitRoot, merkleProof, rollupMerkleProof, nil
 }
 
+// checkDepositIncludedInRoot verifies that the deposit leaf was already part of the
+// exit tree when the given root was computed. Without this check, getProof can walk
+// one index past the last leaf of the tree (the frontier nodes persisted by addLeaf
+// have zero-hash right children) and return a valid proof of the EMPTY leaf instead
+// of failing, presenting it as a legitimate claim proof for a non-included deposit.
+func (s *bridgeService) checkDepositIncludedInRoot(ctx context.Context, depositCnt, networkID uint32, root common.Hash, dbTx interface{}) error {
+	lastDepositCnt, err := s.storage.GetDepositCountByRoot(ctx, root[:], networkID, dbTx)
+	if err != nil {
+		return fmt.Errorf("error getting deposit count for exit root: %s, network: %d. Err: %w", root.String(), networkID, err)
+	}
+	if depositCnt > lastDepositCnt {
+		return fmt.Errorf("deposit %d for network %d is not included in the exit root %s (last included deposit: %d)",
+			depositCnt, networkID, root.String(), lastDepositCnt)
+	}
+	return nil
+}
+
 // GetClaimProofbyGER returns the merkle proof to claim the given deposit.
 func (s *bridgeService) GetClaimProofbyGER(ctx context.Context, depositCnt, networkID uint32, GER common.Hash, dbTx interface{}) (*etherman.GlobalExitRoot, [][bridgectrl.KeyLen]byte, [][bridgectrl.KeyLen]byte, error) {
 	if dbTx == nil { // if the call comes from the rest API
@@ -230,6 +247,10 @@ func (s *bridgeService) GetClaimProofbyGER(ctx context.Context, depositCnt, netw
 		rollupLeaf        common.Hash
 	)
 	if networkID == 0 { // Mainnet
+		if err := s.checkDepositIncludedInRoot(ctx, depositCnt, networkID, globalExitRoot.ExitRoots[0], dbTx); err != nil {
+			log.Errorf("deposit not included in root. Error: %v", err)
+			return nil, nil, nil, err
+		}
 		merkleProof, err = s.getProof(ctx, depositCnt, globalExitRoot.ExitRoots[0], dbTx)
 		if err != nil {
 			log.Errorf("error getting merkleProof. Error: %w", err)
@@ -241,6 +262,10 @@ func (s *bridgeService) GetClaimProofbyGER(ctx context.Context, depositCnt, netw
 		if err != nil {
 			log.Errorf("error getting rollupProof. Error: %w", err)
 			return nil, nil, nil, fmt.Errorf("getting the rollupexit proof failed, error: %v, network: %d", err, networkID)
+		}
+		if err := s.checkDepositIncludedInRoot(ctx, depositCnt, networkID, rollupLeaf, dbTx); err != nil {
+			log.Errorf("deposit not included in root. Error: %v", err)
+			return nil, nil, nil, err
 		}
 		merkleProof, err = s.getProof(ctx, depositCnt, rollupLeaf, dbTx)
 		if err != nil {
@@ -276,6 +301,10 @@ func (s *bridgeService) GetClaimProofForCompressed(ctx context.Context, ger comm
 		rollupLeaf        common.Hash
 	)
 	if networkID == 0 { // Mainnet
+		if err := s.checkDepositIncludedInRoot(ctx, depositCnt, networkID, globalExitRoot.ExitRoots[0], dbTx); err != nil {
+			log.Errorf("deposit not included in root. Error: %v", err)
+			return nil, nil, nil, err
+		}
 		merkleProof, err = s.getProof(ctx, depositCnt, globalExitRoot.ExitRoots[0], dbTx)
 		if err != nil {
 			log.Error("error getting merkleProof. Error: ", err)
@@ -287,6 +316,10 @@ func (s *bridgeService) GetClaimProofForCompressed(ctx context.Context, ger comm
 		if err != nil {
 			log.Error("error getting rollupProof. Error: ", err)
 			return nil, nil, nil, fmt.Errorf("getting the rollup proof failed, error: %v, network: %d", err, networkID)
+		}
+		if err := s.checkDepositIncludedInRoot(ctx, depositCnt, networkID, rollupLeaf, dbTx); err != nil {
+			log.Errorf("deposit not included in root. Error: %v", err)
+			return nil, nil, nil, err
 		}
 		merkleProof, err = s.getProof(ctx, depositCnt, rollupLeaf, dbTx)
 		if err != nil {
@@ -473,7 +506,7 @@ func (s *bridgeService) GetProof(ctx context.Context, req *pb.GetProofRequest) (
 		proof       []string
 		rollupProof []string
 	)
-	if len(proof) != len(rollupProof) {
+	if len(merkleProof) != len(rollupMerkleProof) {
 		return nil, fmt.Errorf("proofs have different lengths. MerkleProof: %d. RollupMerkleProof: %d", len(merkleProof), len(rollupMerkleProof))
 	}
 	for i := 0; i < len(merkleProof); i++ {
@@ -575,7 +608,7 @@ func (s *bridgeService) GetProofByGER(ctx context.Context, req *pb.GetProofByGER
 		proof       []string
 		rollupProof []string
 	)
-	if len(proof) != len(rollupProof) {
+	if len(merkleProof) != len(rollupMerkleProof) {
 		return nil, fmt.Errorf("proofs have different lengths. MerkleProof: %d. RollupMerkleProof: %d", len(merkleProof), len(rollupMerkleProof))
 	}
 	for i := 0; i < len(merkleProof); i++ {
@@ -664,7 +697,7 @@ func (s *bridgeService) GetProofV2(ctx context.Context, req *pb.GetProofV2Reques
 		proof       []string
 		rollupProof []string
 	)
-	if len(proof) != len(rollupProof) {
+	if len(merkleProof) != len(rollupMerkleProof) {
 		return nil, fmt.Errorf("proofs have different lengths. MerkleProof: %d. RollupMerkleProof: %d", len(merkleProof), len(rollupMerkleProof))
 	}
 	for i := 0; i < len(merkleProof); i++ {

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -2,9 +2,13 @@ package server
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
+	"github.com/0xPolygon/zkevm-bridge-service/bridgectrl"
+	"github.com/0xPolygon/zkevm-bridge-service/bridgectrl/pb"
 	"github.com/0xPolygon/zkevm-bridge-service/etherman"
+	"github.com/0xPolygon/zkevm-bridge-service/utils/gerror"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -27,6 +31,7 @@ func TestGetClaimProofbyGER(t *testing.T) {
 		ExitRoots: []common.Hash{{}, {}},
 	}
 	mockStorage.EXPECT().GetL1ExitRootByGER(mock.Anything, GER, mock.Anything).Return(&exitRoot, nil)
+	mockStorage.EXPECT().GetDepositCountByRoot(mock.Anything, mock.Anything, networkID, mock.Anything).Return(uint32(0), nil)
 	node := [][]byte{{}, {}}
 	mockStorage.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(node, nil)
 	smtProof, smtRollupProof, globaExitRoot, err := sut.GetClaimProofbyGER(context.Background(), depositCnt, networkID, GER, nil)
@@ -34,4 +39,276 @@ func TestGetClaimProofbyGER(t *testing.T) {
 	require.NotNil(t, smtProof)
 	require.NotNil(t, smtRollupProof)
 	require.NotNil(t, globaExitRoot)
+}
+
+const testTreeHeight = 32
+
+// inMemoryExitTree replicates the persistence pattern of bridgectrl.MerkleTree.addLeaf:
+// for every level of an inserted leaf's path it stores parent -> (left child, right child)
+// in a reverse hash table, exactly like the mt.rht table used by the bridge service.
+type inMemoryExitTree struct {
+	count      uint32
+	siblings   [][bridgectrl.KeyLen]byte
+	zeroHashes [][bridgectrl.KeyLen]byte
+	// nodes is the reverse hash table: parent hash -> [left, right]
+	nodes map[[bridgectrl.KeyLen]byte][][]byte
+	root  [bridgectrl.KeyLen]byte
+}
+
+func newInMemoryExitTree() *inMemoryExitTree {
+	zeroHashes := make([][bridgectrl.KeyLen]byte, testTreeHeight+1)
+	for h := 1; h <= testTreeHeight; h++ {
+		zeroHashes[h] = bridgectrl.Hash(zeroHashes[h-1], zeroHashes[h-1])
+	}
+	siblings := make([][bridgectrl.KeyLen]byte, testTreeHeight)
+	for h := 0; h < testTreeHeight; h++ {
+		siblings[h] = zeroHashes[h]
+	}
+	return &inMemoryExitTree{
+		siblings:   siblings,
+		zeroHashes: zeroHashes,
+		nodes:      make(map[[bridgectrl.KeyLen]byte][][]byte),
+		root:       zeroHashes[testTreeHeight],
+	}
+}
+
+// addLeaf mirrors bridgectrl.(*MerkleTree).addLeaf.
+func (t *inMemoryExitTree) addLeaf(leaf [bridgectrl.KeyLen]byte) {
+	index := t.count
+	cur := leaf
+	isFilledSubTree := true
+	for h := uint8(0); h < testTreeHeight; h++ {
+		var parent [bridgectrl.KeyLen]byte
+		if index&(1<<h) > 0 {
+			parent = bridgectrl.Hash(t.siblings[h], cur)
+			t.nodes[parent] = [][]byte{append([]byte{}, t.siblings[h][:]...), append([]byte{}, cur[:]...)}
+		} else {
+			if isFilledSubTree {
+				t.siblings[h] = cur
+				isFilledSubTree = false
+			}
+			parent = bridgectrl.Hash(cur, t.zeroHashes[h])
+			t.nodes[parent] = [][]byte{append([]byte{}, cur[:]...), append([]byte{}, t.zeroHashes[h][:]...)}
+		}
+		cur = parent
+	}
+	t.root = cur
+	t.count++
+}
+
+// computeRootFromProof rebuilds the root from a leaf, its index and a proof
+// (same algorithm as the on-chain claim verification).
+func computeRootFromProof(leaf [bridgectrl.KeyLen]byte, index uint32, proof [][bridgectrl.KeyLen]byte) common.Hash {
+	node := leaf
+	for h := uint8(0); h < testTreeHeight; h++ {
+		if (index>>h)&1 == 1 {
+			node = bridgectrl.Hash(proof[h], node)
+		} else {
+			node = bridgectrl.Hash(node, proof[h])
+		}
+	}
+	return common.BytesToHash(node[:])
+}
+
+func newTestDeposit(depositCount uint32) *etherman.Deposit {
+	return &etherman.Deposit{
+		LeafType:           0,
+		OriginalNetwork:    0,
+		OriginalAddress:    common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		Amount:             big.NewInt(1000000 + int64(depositCount)),
+		DestinationNetwork: 1,
+		DestinationAddress: common.HexToAddress("0x2222222222222222222222222222222222222222"),
+		DepositCount:       depositCount,
+		NetworkID:          0,
+		Metadata:           []byte{},
+	}
+}
+
+// newSutWithExitTree wires a bridgeService whose storage mock serves an
+// in-memory replica of the exit tree of the given network frozen at the moment
+// a GER was published, while the deposit table contains more (later) deposits.
+// The GetDepositCountByRoot mock resolves the last deposit count only for the
+// frozen root, mirroring the mt.root table semantics.
+func newSutWithExitTree(t *testing.T, tree *inMemoryExitTree, deposits []*etherman.Deposit, ger common.Hash, networkID uint32) *bridgeService {
+	t.Helper()
+	mockStorage := newBridgeServiceStorageMock(t)
+	sut := NewBridgeService(Config{CacheSize: 32}, testTreeHeight, []uint32{0, 1}, mockStorage)
+
+	treeRoot := common.BytesToHash(tree.root[:])
+	mockStorage.EXPECT().GetDeposit(mock.Anything, mock.Anything, networkID, mock.Anything).RunAndReturn(
+		func(_ context.Context, depositCnt, _ uint32, _ interface{}) (*etherman.Deposit, error) {
+			if int(depositCnt) < len(deposits) {
+				return deposits[depositCnt], nil
+			}
+			return nil, gerror.ErrStorageNotFound
+		})
+	mainnetRoot := common.Hash{}
+	rollupRoot := common.Hash{}
+	if networkID == 0 {
+		mainnetRoot = treeRoot
+	} else {
+		// The rollup exit tree contains the frozen L2 exit root (LER) as its only leaf.
+		leaves := [][bridgectrl.KeyLen]byte{tree.root}
+		_, computedRollupRoot, err := bridgectrl.ComputeSiblings(networkID-1, leaves, testTreeHeight)
+		require.NoError(t, err)
+		rollupRoot = computedRollupRoot
+		mockStorage.EXPECT().GetRollupExitLeavesByRoot(mock.Anything, rollupRoot, mock.Anything).Return(
+			[]etherman.RollupExitLeaf{{RollupId: networkID, Leaf: treeRoot, Root: rollupRoot}}, nil)
+	}
+	mockStorage.EXPECT().GetL1ExitRootByGER(mock.Anything, ger, mock.Anything).Return(
+		&etherman.GlobalExitRoot{
+			GlobalExitRoot: ger,
+			ExitRoots:      []common.Hash{mainnetRoot, rollupRoot},
+		}, nil)
+	mockStorage.EXPECT().GetDepositCountByRoot(mock.Anything, mock.Anything, networkID, mock.Anything).RunAndReturn(
+		func(_ context.Context, root []byte, _ uint32, _ interface{}) (uint32, error) {
+			if common.BytesToHash(root) == treeRoot && tree.count > 0 {
+				return tree.count - 1, nil
+			}
+			return 0, gerror.ErrStorageNotFound
+		})
+	// Maybe(): requests rejected by the inclusion check never reach the tree traversal.
+	mockStorage.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, key []byte, _ interface{}) ([][]byte, error) {
+			var k [bridgectrl.KeyLen]byte
+			copy(k[:], key)
+			if node, ok := tree.nodes[k]; ok {
+				return node, nil
+			}
+			return nil, gerror.ErrStorageNotFound
+		}).Maybe()
+	return sut
+}
+
+// TestGetProofByGERRejectsDepositNotInTree is the regression test for the
+// off-by-one bug of the merkle-proof-by-ger API.
+//
+// Scenario: the exit root referenced by the GER was computed when the tree had
+// 3 leaves (deposits 0, 1, 2). Deposit 3 was synced into the DB later, so it
+// exists, but it is NOT part of that exit root.
+//
+// Before the fix, querying deposit_cnt=3 returned a 32-sibling proof without
+// error: bridgectrl.MerkleTree.addLeaf persists frontier nodes with zero-hash
+// right children, so getProof could walk one index past the last leaf whenever
+// the last inserted leaf had an even index. The returned siblings were a valid
+// Merkle proof of the ZERO leaf at index 3 (a proof of vacancy), presented as
+// a legitimate claim proof that would revert on-chain.
+//
+// With the fix, the deposit count is validated against the root
+// (GetDepositCountByRoot) before traversing the tree, so any deposit_cnt
+// beyond the last included leaf is rejected with a clear error.
+func TestGetProofByGERRejectsDepositNotInTree(t *testing.T) {
+	ctx := context.Background()
+	ger := common.HexToHash("0x1234")
+
+	deposits := make([]*etherman.Deposit, 5)
+	for i := range deposits {
+		deposits[i] = newTestDeposit(uint32(i))
+	}
+
+	// Freeze the exit tree with 3 leaves: deposits 0..2. Last leaf index = 2 (even),
+	// the parity that used to trigger the off-by-one.
+	tree := newInMemoryExitTree()
+	for i := 0; i < 3; i++ {
+		tree.addLeaf(bridgectrl.HashDeposit(deposits[i]))
+	}
+	root := common.BytesToHash(tree.root[:])
+	sut := newSutWithExitTree(t, tree, deposits, ger, 0)
+
+	t.Run("included deposit returns a valid proof", func(t *testing.T) {
+		_, proof, _, err := sut.GetClaimProofbyGER(ctx, 2, 0, ger, nil)
+		require.NoError(t, err)
+		require.Len(t, proof, testTreeHeight)
+		require.Equal(t, root, computeRootFromProof(bridgectrl.HashDeposit(deposits[2]), 2, proof),
+			"proof for an included deposit must verify against the exit root")
+	})
+
+	t.Run("deposit_cnt == leaf count is rejected (off-by-one regression)", func(t *testing.T) {
+		_, proof, _, err := sut.GetClaimProofbyGER(ctx, 3, 0, ger, nil)
+		require.Error(t, err, "deposit 3 is not part of this GER's exit root, no proof must be returned")
+		require.ErrorContains(t, err, "is not included in the exit root")
+		require.Nil(t, proof)
+	})
+
+	t.Run("rejection surfaces through the GetProofByGER endpoint as well", func(t *testing.T) {
+		resp, err := sut.GetProofByGER(ctx, &pb.GetProofByGERRequest{
+			NetId:      0,
+			DepositCnt: 3,
+			Ger:        ger.Hex(),
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "is not included in the exit root")
+		require.Nil(t, resp)
+	})
+
+	t.Run("deposit_cnt beyond leaf count + 1 is rejected too", func(t *testing.T) {
+		_, _, _, err := sut.GetClaimProofbyGER(ctx, 4, 0, ger, nil)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "is not included in the exit root")
+	})
+}
+
+// TestGetProofByGERRejectsDepositNotInTreeEvenLeafCount covers the parity that
+// never triggered the off-by-one (last inserted leaf with an odd index). The
+// request must still be rejected, now with the explicit inclusion error
+// instead of the incidental storage-lookup failure of the tree traversal.
+func TestGetProofByGERRejectsDepositNotInTreeEvenLeafCount(t *testing.T) {
+	ctx := context.Background()
+	ger := common.HexToHash("0x5678")
+
+	deposits := make([]*etherman.Deposit, 3)
+	for i := range deposits {
+		deposits[i] = newTestDeposit(uint32(i))
+	}
+
+	// Freeze the exit tree with 2 leaves: deposits 0..1. Last leaf index = 1 (odd).
+	tree := newInMemoryExitTree()
+	for i := 0; i < 2; i++ {
+		tree.addLeaf(bridgectrl.HashDeposit(deposits[i]))
+	}
+	sut := newSutWithExitTree(t, tree, deposits, ger, 0)
+
+	_, _, _, err := sut.GetClaimProofbyGER(ctx, 2, 0, ger, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "is not included in the exit root")
+}
+
+// TestGetProofByGERRejectsDepositNotInTreeRollup exercises the rollup branch of
+// GetClaimProofbyGER: the L2 exit tree (LER) referenced through the rollup exit
+// root has 3 leaves, and the same off-by-one index (deposit_cnt == leaf count)
+// must be rejected there as well.
+func TestGetProofByGERRejectsDepositNotInTreeRollup(t *testing.T) {
+	ctx := context.Background()
+	ger := common.HexToHash("0x9abc")
+	const networkID = uint32(1)
+
+	deposits := make([]*etherman.Deposit, 5)
+	for i := range deposits {
+		deposits[i] = newTestDeposit(uint32(i))
+		deposits[i].NetworkID = networkID
+		deposits[i].DestinationNetwork = 0
+	}
+
+	// Freeze the L2 exit tree with 3 leaves: deposits 0..2. Last leaf index = 2 (even).
+	tree := newInMemoryExitTree()
+	for i := 0; i < 3; i++ {
+		tree.addLeaf(bridgectrl.HashDeposit(deposits[i]))
+	}
+	ler := common.BytesToHash(tree.root[:])
+	sut := newSutWithExitTree(t, tree, deposits, ger, networkID)
+
+	t.Run("included deposit returns a valid proof against the LER", func(t *testing.T) {
+		_, proof, rollupProof, err := sut.GetClaimProofbyGER(ctx, 2, networkID, ger, nil)
+		require.NoError(t, err)
+		require.Len(t, proof, testTreeHeight)
+		require.Len(t, rollupProof, testTreeHeight)
+		require.Equal(t, ler, computeRootFromProof(bridgectrl.HashDeposit(deposits[2]), 2, proof),
+			"proof for an included deposit must verify against the L2 exit root")
+	})
+
+	t.Run("deposit_cnt == leaf count is rejected (off-by-one regression)", func(t *testing.T) {
+		_, _, _, err := sut.GetClaimProofbyGER(ctx, 3, networkID, ger, nil)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "is not included in the exit root")
+	})
 }

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -110,7 +110,7 @@ func computeRootFromProof(leaf [bridgectrl.KeyLen]byte, index uint32, proof [][b
 	return common.BytesToHash(node[:])
 }
 
-func newTestDeposit(depositCount uint32) *etherman.Deposit {
+func newTestDeposit(depositCount int) *etherman.Deposit {
 	return &etherman.Deposit{
 		LeafType:           0,
 		OriginalNetwork:    0,
@@ -118,7 +118,7 @@ func newTestDeposit(depositCount uint32) *etherman.Deposit {
 		Amount:             big.NewInt(1000000 + int64(depositCount)),
 		DestinationNetwork: 1,
 		DestinationAddress: common.HexToAddress("0x2222222222222222222222222222222222222222"),
-		DepositCount:       depositCount,
+		DepositCount:       uint32(depositCount), //nolint:gosec
 		NetworkID:          0,
 		Metadata:           []byte{},
 	}
@@ -203,7 +203,7 @@ func TestGetProofByGERRejectsDepositNotInTree(t *testing.T) {
 
 	deposits := make([]*etherman.Deposit, 5)
 	for i := range deposits {
-		deposits[i] = newTestDeposit(uint32(i))
+		deposits[i] = newTestDeposit(i)
 	}
 
 	// Freeze the exit tree with 3 leaves: deposits 0..2. Last leaf index = 2 (even),
@@ -258,7 +258,7 @@ func TestGetProofByGERRejectsDepositNotInTreeEvenLeafCount(t *testing.T) {
 
 	deposits := make([]*etherman.Deposit, 3)
 	for i := range deposits {
-		deposits[i] = newTestDeposit(uint32(i))
+		deposits[i] = newTestDeposit(i)
 	}
 
 	// Freeze the exit tree with 2 leaves: deposits 0..1. Last leaf index = 1 (odd).
@@ -284,7 +284,7 @@ func TestGetProofByGERRejectsDepositNotInTreeRollup(t *testing.T) {
 
 	deposits := make([]*etherman.Deposit, 5)
 	for i := range deposits {
-		deposits[i] = newTestDeposit(uint32(i))
+		deposits[i] = newTestDeposit(i)
 		deposits[i].NetworkID = networkID
 		deposits[i].DestinationNetwork = 0
 	}


### PR DESCRIPTION
## Bug

The `merkle-proof-by-ger` endpoint (`GetProofByGER` → `GetClaimProofbyGER`) could return a Merkle proof for a `deposit_cnt` that is **not** included in the exit tree referenced by the requested GER.

`GetClaimProofbyGER` relied on the tree traversal (`getProof`) failing for non-included deposits. But `bridgectrl.MerkleTree.addLeaf` persists frontier nodes with zero-hash right children, so when the last inserted leaf has an **even** index, `getProof` can walk exactly **one index past** the last leaf using only stored nodes. It then returns a valid 32-sibling proof — but of the **empty leaf**, not the deposit.

Concretely, with an exit root covering leaves `0..N-1`:
- `deposit_cnt = N` (N-1 even) → returns a proof of the zero leaf, **no error**.
- `deposit_cnt >= N+1` → correctly errors.

So the boundary behaviour flips with the parity of the tree size. The returned proof is cryptographically valid for the empty leaf and would **revert on-chain** if used to claim, yet the API presents it as a legitimate claim proof.

## Fix

Validate inclusion explicitly before traversing. New helper `checkDepositIncludedInRoot` resolves the last deposit count covered by the exit root via `storage.GetDepositCountByRoot` (already in the storage interface) and rejects any `deposit_cnt` beyond it, in both the mainnet and rollup branches of `GetClaimProofbyGER`.

Scope is limited to the `merkle-proof-by-ger` path — all other endpoints (`GetProof`, `GetProofV2`, `GetClaimProofForCompressed`) are byte-identical to `develop`. Also fixed a dead length-check inside the `GetProofByGER` handler (compared two still-empty slices).

## Tests

`server/service_test.go`, backed by an in-memory replica of the exit tree mirroring `addLeaf`'s exact persistence pattern (real `getProof` traversal, no Postgres):
- `TestGetProofByGERRejectsDepositNotInTree` — even leaf count (the triggering parity): included deposit verifies against the root; off-by-one index and beyond are rejected, at service level and through the endpoint.
- `TestGetProofByGERRejectsDepositNotInTreeEvenLeafCount` — odd leaf count: rejected with the explicit inclusion error.
- `TestGetProofByGERRejectsDepositNotInTreeRollup` — rollup branch (LER via rollup exit root).

## Note

`GetClaimProofForCompressed` (claimtxman grouped claims) shares the same traversal and bug shape. It was intentionally left untouched here to avoid affecting the auto-claim flow and should be evaluated separately.

Made with [Cursor](https://cursor.com)